### PR TITLE
don't log timestamp when not in tty

### DIFF
--- a/denon_proxy.py
+++ b/denon_proxy.py
@@ -63,11 +63,20 @@ from http_server import run_http_server
 # -----------------------------------------------------------------------------
 
 def setup_logging(level: str = "INFO", denonavr_log_level: str | None = None) -> None:
-    """Configure logging format and level. denonavr_log_level sets the denonavr library logger separately."""
+    """Configure logging format and level. denonavr_log_level sets the denonavr library logger separately.
+    When stdout is not a TTY (e.g. systemd captures it), we use a format without timestamp/name
+    so journal/syslog doesn't duplicate them."""
+    log_level = getattr(logging, level.upper(), logging.INFO)
+    if sys.stdout.isatty():
+        fmt = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+        datefmt = "%Y-%m-%d %H:%M:%S"
+    else:
+        fmt = "[%(levelname)s] %(message)s"
+        datefmt = None
     logging.basicConfig(
-        level=getattr(logging, level.upper(), logging.INFO),
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+        level=log_level,
+        format=fmt,
+        datefmt=datefmt,
     )
     # Reduce noise from libraries
     logging.getLogger("httpx").setLevel(logging.WARNING)


### PR DESCRIPTION
systemd logs a timestamp already, when running as a service we don't need to log one as well