### PR TITLE
add client alias support

### DIFF
--- a/avr_discovery.py
+++ b/avr_discovery.py
@@ -582,6 +582,7 @@ class DeviceDescriptionHandler(asyncio.Protocol):
 
             peername = self.transport.get_extra_info("peername") if self.transport else None
             client_ip = peername[0] if peername else "?"
+            client_display = self.config.client_display_for_log(client_ip)
 
             if body is not None:
                 resp = (
@@ -591,12 +592,12 @@ class DeviceDescriptionHandler(asyncio.Protocol):
                     b"Connection: close\r\n\r\n"
                 ) + body
                 self.transport.write(resp)
-                self.logger.debug("Client %s request: %s %s -> 200 OK", client_ip, method, path)
+                self.logger.debug("Client %s request: %s %s -> 200 OK", client_display, method, path)
             else:
                 if path_lower == "/ws":
-                    self.logger.debug("Client %s request: %s %s -> no handler", client_ip, method, path)
+                    self.logger.debug("Client %s request: %s %s -> no handler", client_display, method, path)
                 else:
-                    self.logger.warning("Client %s request: %s %s -> no handler", client_ip, method, path)
+                    self.logger.warning("Client %s request: %s %s -> no handler", client_display, method, path)
         except OSError as e:
             self.logger.warning("HTTP handler error: %s", e)
         self._close()

--- a/config.py
+++ b/config.py
@@ -38,6 +38,8 @@ class Config(Mapping[str, Any]):
     # Optional/less common config keys
     ssdp_friendly_name: str | None = None
     sources: Any | None = None
+    # IP -> friendly name for connected clients (e.g. {"192.168.1.5": "Living Room HA"})
+    client_aliases: dict[str, str] = field(default_factory=dict)
 
     # Mapping interface (read-only) --------------------------------------
 
@@ -47,7 +49,7 @@ class Config(Mapping[str, Any]):
             "denonavr_log_level", "enable_ssdp", "ssdp_http_port", "ssdp_advertise_ip",
             "optimistic_state", "optimistic_broadcast_delay", "volume_step", "volume_query_delay",
             "enable_http", "http_port", "log_command_groups_info",
-            "ssdp_friendly_name", "sources",
+            "ssdp_friendly_name", "sources", "client_aliases",
         }
     )
 
@@ -71,7 +73,10 @@ class Config(Mapping[str, Any]):
     def _apply_dict(self, other: Mapping[str, Any]) -> None:
         for k in self._FIELDS:
             if k in other:
-                setattr(self, k, other[k])
+                val = other[k]
+                if k == "client_aliases" and val is not None and not isinstance(val, dict):
+                    val = dict(val) if hasattr(val, "items") else {}
+                setattr(self, k, val)
 
     @classmethod
     def from_dict(cls, raw: TypingMapping[str, Any] | None) -> "Config":
@@ -116,5 +121,12 @@ class Config(Mapping[str, Any]):
         """
         if not (self.avr_host or "").strip():
             self.optimistic_state = False
+
+    def client_display_for_log(self, ip: str) -> str:
+        """Return IP for logging; if config has an alias for this IP, return 'alias (ip)'."""
+        aliases = self.get("client_aliases") or {}
+        if isinstance(aliases, dict) and ip and ip in aliases:
+            return f"{aliases[ip]} ({ip})"
+        return ip or "?"
 
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -75,3 +75,8 @@ optimistic_broadcast_delay: 0.1
 # HTTP interface: JSON API and Web UI
 enable_http: true
 http_port: 8081
+
+# Optional: friendly names for clients by IP (shown in Web UI and API)
+# client_aliases:
+#   "192.168.1.5": "Living Room Home Assistant"
+#   "192.168.1.10": "UC Remote 3"

--- a/denon_proxy.py
+++ b/denon_proxy.py
@@ -226,11 +226,16 @@ def build_json_state(
         "proxy_ip_is_internal": is_docker_internal_ip(proxy_ip),
         "is_docker": is_running_in_docker(),
     }
+    client_aliases = config.get("client_aliases") or {}
+    if not isinstance(client_aliases, dict):
+        client_aliases = {}
+
     return {
         "friendly_name": runtime_state.get_friendly_name(config),
         "avr": avr_dict,
         "clients": client_ips,
         "client_count": len(client_ips),
+        "client_aliases": client_aliases,
         "state": state_dict,
         "discovery": discovery,
         "version": runtime_state.version,
@@ -352,7 +357,10 @@ class ClientHandler(asyncio.Protocol):
         self.transport = transport
         self._peername = transport.get_extra_info("peername")
         self.clients.add(self)
-        self.logger.info("Client connected: %s (total: %d)", self._peername, len(self.clients))
+        client_display = self.config.client_display_for_log(
+            self._peername[0] if self._peername else "?"
+        )
+        self.logger.info("Client connected: %s (total: %d)", client_display, len(self.clients))
         self._notify_web()
 
         # Send current state to new client
@@ -372,10 +380,11 @@ class ClientHandler(asyncio.Protocol):
             return
 
         client_ip = self._peername[0] if self._peername else "?"
+        client_display = self.config.client_display_for_log(client_ip)
         if _should_log_command_info(self.config, command):
-            self.logger.info("Client %s command: %s", client_ip, command)
+            self.logger.info("Client %s command: %s", client_display, command)
         else:
-            self.logger.debug("Client %s command: %s", client_ip, command)
+            self.logger.debug("Client %s command: %s", client_display, command)
         asyncio.create_task(self._handle_command_async(command))
 
     def _broadcast_state(self) -> None:
@@ -436,7 +445,10 @@ class ClientHandler(asyncio.Protocol):
         """Called when client disconnects."""
         self.clients.discard(self)
         self.transport = None
-        self.logger.info("Client disconnected: %s (remaining: %d)", self._peername, len(self.clients))
+        client_display = self.config.client_display_for_log(
+            self._peername[0] if self._peername else "?"
+        )
+        self.logger.info("Client disconnected: %s (remaining: %d)", client_display, len(self.clients))
         self._notify_web()
 
 

--- a/tests/unit/test_denon_proxy_config.py
+++ b/tests/unit/test_denon_proxy_config.py
@@ -69,6 +69,16 @@ def test_apply_env_overrides_leaves_config_unchanged_when_env_unset():
     assert config["avr_port"] == 23
 
 
+def test_client_display_for_log_uses_alias_when_configured():
+    """Config.client_display_for_log returns 'alias (ip)' when client_aliases set, else ip."""
+    config = load_config_from_dict({"client_aliases": {"192.168.1.5": "Living Room HA"}})
+    assert config.client_display_for_log("192.168.1.5") == "Living Room HA (192.168.1.5)"
+    assert config.client_display_for_log("10.0.0.1") == "10.0.0.1"
+    assert config.client_display_for_log("?") == "?"
+    config_empty = load_config_from_dict({})
+    assert config_empty.client_display_for_log("192.168.1.5") == "192.168.1.5"
+
+
 def test_load_config_dict_from_file_raises_file_not_found_when_missing():
     """Missing config path raises FileNotFoundError with the path in the message."""
     pytest.importorskip("yaml")

--- a/tests/unit/test_denon_proxy_helpers.py
+++ b/tests/unit/test_denon_proxy_helpers.py
@@ -104,7 +104,7 @@ def test_build_json_state_structure_and_volume_conversion():
 
     result = build_json_state(state, avr, clients, config, runtime_state)
 
-    assert set(result.keys()) == {"friendly_name", "avr", "clients", "client_count", "state", "discovery", "version"}
+    assert set(result.keys()) == {"friendly_name", "avr", "clients", "client_count", "client_aliases", "state", "discovery", "version"}
     assert result["friendly_name"] == "My AVR Proxy"
     assert result["client_count"] == 2
     assert result["clients"] == ["10.0.0.1", "10.0.0.2"]
@@ -139,6 +139,18 @@ def test_build_json_state_with_virtual_avr_info():
     assert avr_dict["model_name"] == "Virtual"
     assert avr_dict["serial_number"] is None
     assert avr_dict["friendly_name"] is None
+
+
+def test_build_json_state_includes_client_aliases():
+    """build_json_state includes client_aliases from config."""
+    state = AVRState()
+    config = load_config_from_dict({
+        "client_aliases": {"192.168.1.5": "Living Room HA", "10.0.0.1": "Tablet"},
+    })
+    runtime_state = RuntimeState()
+    runtime_state.avr_info = AVRInfo.virtual()
+    result = build_json_state(state, None, [], config, runtime_state)
+    assert result["client_aliases"] == {"192.168.1.5": "Living Room HA", "10.0.0.1": "Tablet"}
 
 
 def test_build_json_state_includes_discovery_info():

--- a/tests/unit/test_http_server_api.py
+++ b/tests/unit/test_http_server_api.py
@@ -92,6 +92,7 @@ async def test_http_get_status_json_shape():
                 "avr",
                 "clients",
                 "client_count",
+                "client_aliases",
                 "state",
                 "discovery",
                 "version",

--- a/web_ui.html
+++ b/web_ui.html
@@ -300,8 +300,14 @@
           proxyIpNote.style.display = 'none';
         }
       }
+      const aliases = d.client_aliases || {};
+      const clientDisplay = (c) => {
+        const ip = typeof c === 'string' ? c : (c && c.ip);
+        const name = ip && aliases[ip] ? (escapeHtml(aliases[ip]) + ' <span class="muted">(' + escapeHtml(ip) + ')</span>') : escapeHtml(ip || '?');
+        return name;
+      };
       document.getElementById('clients').innerHTML = clients.length
-        ? '<ul class="client-list">' + clients.map(c => '<li>' + escapeHtml(c) + '</li>').join('') + '</ul>'
+        ? '<ul class="client-list">' + clients.map(c => '<li>' + clientDisplay(c) + '</li>').join('') + '</ul>'
         : '<span class="muted">No clients connected</span>';
       const dockerClientsNote = document.getElementById('docker-clients-note');
       if (dockerClientsNote) dockerClientsNote.style.display = (d.discovery && d.discovery.is_docker) ? 'block' : 'none';


### PR DESCRIPTION
Allow users to name clients by IP in the UI, logs, and api