### PR TITLE
Feature: dynamic log filtering

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -27,10 +27,10 @@ denonavr_log_level: "INFO"
 # Groups: power, volume, input, mute, sound_mode, smart_select, other. Default: none (all DEBUG when log_level is DEBUG).
 log_command_groups_info: []
 
-# Physical AVR only: reduce log noise from telnet commands the AVR never answers (e.g. unsupported queries).
-# When dynamic_command_filtering is true and avr_host is set, the proxy tracks unanswered sends; after
-# avr_unanswered_log_suppress_after misses, suppresses "Client … command" and "Sent to AVR" for that command
-# until a matching response or restart. Set dynamic_command_filtering to false to disable.
+# Physical AVR only: reduce log noise from telnet *queries* (lines ending with '?') the AVR never answers.
+# When dynamic_command_filtering is true and avr_host is set, the proxy tracks unanswered query sends; after
+# avr_unanswered_log_suppress_after misses, suppresses "Client … command" and "Sent to AVR" for that query
+# until a matching response or restart. Set commands are never tracked or suppressed. Set dynamic_command_filtering to false to disable.
 dynamic_command_filtering: true
 # Unanswered sends (see avr_unanswered_response_timeout) before suppressing logs for that command. Minimum 1 (default 1).
 avr_unanswered_log_suppress_after: 3

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -27,6 +27,16 @@ denonavr_log_level: "INFO"
 # Groups: power, volume, input, mute, sound_mode, smart_select, other. Default: none (all DEBUG when log_level is DEBUG).
 log_command_groups_info: []
 
+# Physical AVR only: reduce log noise from telnet commands the AVR never answers (e.g. unsupported queries).
+# When dynamic_command_filtering is true and avr_host is set, the proxy tracks unanswered sends; after
+# avr_unanswered_log_suppress_after misses, suppresses "Client … command" and "Sent to AVR" for that command
+# until a matching response or restart. Set dynamic_command_filtering to false to disable.
+dynamic_command_filtering: true
+# Unanswered sends (see avr_unanswered_response_timeout) before suppressing logs for that command. Minimum 1 (default 1).
+avr_unanswered_log_suppress_after: 3
+# Seconds to wait after each send for a matching AVR response line before counting that send as unanswered.
+avr_unanswered_response_timeout: 1.0
+
 # Custom input sources: map Denon function codes to display names in Home Assistant.
 # Use this if you only use certain inputs and want names to match your AVR's custom names.
 # Format: dict (func_code: "Display Name"). Set to null to use device/default list.

--- a/src/denon_proxy/avr/connection.py
+++ b/src/denon_proxy/avr/connection.py
@@ -12,6 +12,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any
 
 from denon_proxy.avr.telnet_utils import parse_telnet_lines, telnet_line_to_bytes
+from denon_proxy.avr.unanswered_tracker import is_avr_query_command
 from denon_proxy.command_log import should_log_command_info
 from denon_proxy.constants import AVR_NETWORK_TIMEOUT, REQUEST_STATE_INTERVAL
 
@@ -137,9 +138,13 @@ class AVRConnection:
             writer.write(data)
             await writer.drain()
             stripped = command.strip()
-            if self._unanswered_tracker:
+            if self._unanswered_tracker and is_avr_query_command(stripped):
                 self._unanswered_tracker.note_sent(stripped)
-            suppress = bool(self._unanswered_tracker and self._unanswered_tracker.should_suppress(stripped))
+            suppress = bool(
+                self._unanswered_tracker
+                and is_avr_query_command(stripped)
+                and self._unanswered_tracker.should_suppress(stripped)
+            )
             if not suppress:
                 if should_log_command_info(self._config, stripped):
                     self.logger.info("Sent to AVR: %s", stripped)

--- a/src/denon_proxy/avr/connection.py
+++ b/src/denon_proxy/avr/connection.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
     from denon_proxy.avr.state import AVRState
+    from denon_proxy.avr.unanswered_tracker import UnansweredCommandTracker
     from denon_proxy.runtime.config import Config
 
 # -----------------------------------------------------------------------------
@@ -47,6 +48,7 @@ class AVRConnection:
         logger: logging.Logger,
         on_send_while_disconnected: Callable[[], None] | None = None,
         config: Config | None = None,
+        unanswered_tracker: UnansweredCommandTracker | None = None,
     ) -> None:
         self.host = host
         self.port = port
@@ -55,6 +57,7 @@ class AVRConnection:
         self.on_send_while_disconnected = on_send_while_disconnected
         self.avr_state = avr_state
         self.logger = logger
+        self._unanswered_tracker = unanswered_tracker
         self._config: Mapping[str, Any] = config if config is not None else {}
         self.reader: asyncio.StreamReader | None = None
         self.writer: asyncio.StreamWriter | None = None
@@ -134,10 +137,14 @@ class AVRConnection:
             writer.write(data)
             await writer.drain()
             stripped = command.strip()
-            if should_log_command_info(self._config, stripped):
-                self.logger.info("Sent to AVR: %s", stripped)
-            else:
-                self.logger.debug("Sent to AVR: %s", stripped)
+            if self._unanswered_tracker:
+                self._unanswered_tracker.note_sent(stripped)
+            suppress = bool(self._unanswered_tracker and self._unanswered_tracker.should_suppress(stripped))
+            if not suppress:
+                if should_log_command_info(self._config, stripped):
+                    self.logger.info("Sent to AVR: %s", stripped)
+                else:
+                    self.logger.debug("Sent to AVR: %s", stripped)
             return True
         except OSError as e:
             self.logger.warning("Failed to send command to AVR: %s - %s", command, e)
@@ -252,6 +259,7 @@ def create_avr_connection(
     on_disconnect: Callable[[], None],
     logger: logging.Logger,
     on_send_while_disconnected: Callable[[], None] | None = None,
+    unanswered_tracker: UnansweredCommandTracker | None = None,
 ) -> AVRConnection | VirtualAVRConnection:
     """
     Create an AVR connection based on config. Returns AVRConnection for a
@@ -270,6 +278,7 @@ def create_avr_connection(
             logger=logger,
             on_send_while_disconnected=on_send_while_disconnected,
             config=config,
+            unanswered_tracker=unanswered_tracker,
         )
     return VirtualAVRConnection(
         avr_state=avr_state,

--- a/src/denon_proxy/avr/unanswered_tracker.py
+++ b/src/denon_proxy/avr/unanswered_tracker.py
@@ -1,0 +1,148 @@
+"""
+Track telnet commands the physical AVR does not answer and optionally suppress
+their client / outbound logs after a configured number of timeouts.
+
+Matching a response to a pending command uses Denon-style stems (including MV vs
+MVMAX and MS vs MSSMART). Pending entries are cleared without counting when the
+AVR disconnects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import logging
+
+
+def normalize_command_key(cmd: str) -> str:
+    """Stable key for a telnet line (strip, upper, collapse whitespace)."""
+    return " ".join(cmd.strip().upper().split())
+
+
+def command_stem(cmd_key: str) -> str:
+    """
+    Leading command token without trailing '?' for response matching.
+    "PSIMAX ?" -> PSIMAX, "MV?" -> MV, "PWON" -> PWON.
+    """
+    first = cmd_key.split(maxsplit=1)[0] if cmd_key else ""
+    if "?" in first:
+        return first.split("?", 1)[0]
+    return first
+
+
+def response_matches_command(cmd_key: str, response: str) -> bool:
+    """True if an AVR line likely answers this outbound command."""
+    r = response.strip().upper()
+    if not r or len(r) < 2:
+        return False
+    stem = command_stem(cmd_key)
+    if not stem:
+        return False
+    if stem.startswith("MSSMART"):
+        return r.startswith("MSSMART")
+    if stem == "MS":
+        return r.startswith("MS") and not r.startswith("MSSMART")
+    if stem == "MV":
+        return r.startswith("MV") and not r.startswith("MVMAX")
+    return r.startswith(stem)
+
+
+@dataclass
+class _Pending:
+    uid: int
+    key: str
+    task: asyncio.Task[None]
+
+
+class UnansweredCommandTracker:
+    """
+    For each successful physical send, wait for a matching AVR response within
+    timeout. If none arrives, increment per-command count; at threshold, mark
+    the command suppressed for should_suppress(). A later matching AVR line
+    (for a pending send or unsolicited) clears suppression and the unanswered
+    count. cancel_all_pending() drops waiters without counting (e.g. AVR
+    disconnect).
+    """
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        *,
+        suppress_after: int,
+        response_timeout: float,
+    ) -> None:
+        if suppress_after < 1:
+            raise ValueError("suppress_after must be at least 1")
+        self._logger = logger
+        self._suppress_after = suppress_after
+        self._timeout = response_timeout
+        self._pending: list[_Pending] = []
+        self._next_uid = 0
+        self._unanswered: dict[str, int] = {}
+        self._suppressed: set[str] = set()
+
+    def should_suppress(self, cmd: str) -> bool:
+        return normalize_command_key(cmd) in self._suppressed
+
+    def note_sent(self, cmd: str) -> None:
+        key = normalize_command_key(cmd)
+        uid = self._next_uid
+        self._next_uid += 1
+
+        async def waiter() -> None:
+            try:
+                await asyncio.sleep(self._timeout)
+            except asyncio.CancelledError:
+                return
+            self._complete_timeout(uid)
+
+        p = _Pending(uid=uid, key=key, task=asyncio.create_task(waiter()))
+        self._pending.append(p)
+
+    def on_response(self, message: str) -> None:
+        for i, p in enumerate(self._pending):
+            if response_matches_command(p.key, message):
+                p.task.cancel()
+                self._pending.pop(i)
+                self._unanswered.pop(p.key, None)
+                self._suppressed.discard(p.key)
+                return
+        self._unsuppress_if_suppressed_key_matches(message)
+
+    def cancel_all_pending(self) -> None:
+        for p in self._pending:
+            p.task.cancel()
+        self._pending.clear()
+
+    def _complete_timeout(self, uid: int) -> None:
+        for i, p in enumerate(self._pending):
+            if p.uid == uid:
+                self._pending.pop(i)
+                self._bump(p.key)
+                return
+
+    def _unsuppress_if_suppressed_key_matches(self, message: str) -> None:
+        """Clear suppression when the AVR emits a line matching a suppressed command (no pending)."""
+        candidates = [k for k in self._suppressed if response_matches_command(k, message)]
+        if not candidates:
+            return
+        key = max(candidates, key=lambda k: len(command_stem(k)))
+        self._suppressed.discard(key)
+        self._unanswered.pop(key, None)
+
+    def _bump(self, key: str) -> None:
+        n = self._unanswered.get(key, 0) + 1
+        self._unanswered[key] = n
+        if n >= self._suppress_after and key not in self._suppressed:
+            self._suppressed.add(key)
+            self._logger.info(
+                "AVR command %r had no matching response within %.2fs "
+                "%d time(s); suppressing logs until a matching response or "
+                "process restart (set dynamic_command_filtering: false to disable).",
+                key,
+                self._timeout,
+                n,
+            )

--- a/src/denon_proxy/avr/unanswered_tracker.py
+++ b/src/denon_proxy/avr/unanswered_tracker.py
@@ -1,6 +1,7 @@
 """
-Track telnet commands the physical AVR does not answer and optionally suppress
-their client / outbound logs after a configured number of timeouts.
+Track telnet *query* lines (commands ending with '?') the physical AVR does not
+answer, and optionally suppress their client / outbound logs after a configured
+number of timeouts. Non-query commands are not tracked or suppressed.
 
 Matching a response to a pending command uses Denon-style stems (including MV vs
 MVMAX and MS vs MSSMART). Pending entries are cleared without counting when the
@@ -20,6 +21,12 @@ if TYPE_CHECKING:
 def normalize_command_key(cmd: str) -> str:
     """Stable key for a telnet line (strip, upper, collapse whitespace)."""
     return " ".join(cmd.strip().upper().split())
+
+
+def is_avr_query_command(cmd: str) -> bool:
+    """True if the line is treated as a Denon telnet query (trimmed line ends with '?')."""
+    s = cmd.strip()
+    return len(s) > 0 and s.endswith("?")
 
 
 def command_stem(cmd_key: str) -> str:
@@ -59,12 +66,12 @@ class _Pending:
 
 class UnansweredCommandTracker:
     """
-    For each successful physical send, wait for a matching AVR response within
-    timeout. If none arrives, increment per-command count; at threshold, mark
-    the command suppressed for should_suppress(). A later matching AVR line
-    (for a pending send or unsolicited) clears suppression and the unanswered
-    count. cancel_all_pending() drops waiters without counting (e.g. AVR
-    disconnect).
+    For each successful physical send of a *query* line (see is_avr_query_command),
+    wait for a matching AVR response within timeout. If none arrives, increment
+    per-command count; at threshold, mark the query suppressed for should_suppress().
+    A later matching AVR line (for a pending send or unsolicited) clears
+    suppression and the unanswered count. cancel_all_pending() drops waiters
+    without counting (e.g. AVR disconnect).
     """
 
     def __init__(
@@ -85,9 +92,13 @@ class UnansweredCommandTracker:
         self._suppressed: set[str] = set()
 
     def should_suppress(self, cmd: str) -> bool:
+        if not is_avr_query_command(cmd):
+            return False
         return normalize_command_key(cmd) in self._suppressed
 
     def note_sent(self, cmd: str) -> None:
+        if not is_avr_query_command(cmd):
+            return
         key = normalize_command_key(cmd)
         uid = self._next_uid
         self._next_uid += 1
@@ -139,7 +150,7 @@ class UnansweredCommandTracker:
         if n >= self._suppress_after and key not in self._suppressed:
             self._suppressed.add(key)
             self._logger.info(
-                "AVR command %r had no matching response within %.2fs "
+                "AVR query %r had no matching response within %.2fs "
                 "%d time(s); suppressing logs until a matching response or "
                 "process restart (set dynamic_command_filtering: false to disable).",
                 key,

--- a/src/denon_proxy/proxy/core.py
+++ b/src/denon_proxy/proxy/core.py
@@ -19,6 +19,7 @@ from denon_proxy.avr.discovery import get_advertise_ip
 from denon_proxy.avr.info import AVRInfo
 from denon_proxy.avr.state import AVRState, volume_to_level
 from denon_proxy.avr.telnet_utils import parse_telnet_lines, telnet_line_to_bytes
+from denon_proxy.avr.unanswered_tracker import UnansweredCommandTracker
 from denon_proxy.command_log import (
     should_log_command_info as _should_log_command_info,
 )
@@ -42,10 +43,24 @@ from denon_proxy.utils.utils import (
 if TYPE_CHECKING:
     import logging
     from collections.abc import Callable, Iterable, Mapping
+    from typing import TypeAlias
 
     from denon_proxy.avr.connection import AVRConnection, VirtualAVRConnection
     from denon_proxy.runtime.config import Config
     from denon_proxy.runtime.state import RuntimeState
+
+    AVRFactory: TypeAlias = Callable[
+        [
+            Config,
+            AVRState,
+            Callable[[str], None],
+            Callable[[], None],
+            logging.Logger,
+            Callable[[], None] | None,
+            UnansweredCommandTracker | None,
+        ],
+        AVRConnection | VirtualAVRConnection,
+    ]
 
 
 __all__ = [
@@ -221,6 +236,7 @@ class ClientHandler(asyncio.Protocol):
         config: Config,
         record_command: Callable[[str, str], None] | None = None,
         broadcast_to_all: Callable[[str], None] | None = None,
+        unanswered_tracker: UnansweredCommandTracker | None = None,
     ) -> None:
         self.avr = avr
         self.avr_state = avr_state
@@ -229,6 +245,7 @@ class ClientHandler(asyncio.Protocol):
         self.config = config
         self.runtime_state = runtime_state
         self.broadcast_to_all = broadcast_to_all
+        self.unanswered_tracker = unanswered_tracker
         self.record_command = record_command or (lambda _cid, _cmd: None)
         self.transport: asyncio.Transport | None = None
         self._buffer = b""
@@ -277,10 +294,11 @@ class ClientHandler(asyncio.Protocol):
         client_ip = self._peername[0] if self._peername else "?"
         self.record_command(client_ip, command)
         client_display = self.config.client_display_for_log(client_ip)
-        if _should_log_command_info(self.config, command):
-            self.logger.info("Client %s command: %s", client_display, command)
-        else:
-            self.logger.debug("Client %s command: %s", client_display, command)
+        if not (self.unanswered_tracker and self.unanswered_tracker.should_suppress(command)):
+            if _should_log_command_info(self.config, command):
+                self.logger.info("Client %s command: %s", client_display, command)
+            else:
+                self.logger.debug("Client %s command: %s", client_display, command)
         asyncio.create_task(self._handle_command_async(command))
 
     def _broadcast_state(self) -> None:
@@ -365,17 +383,7 @@ class DenonProxyServer:
         self,
         config: Config,
         logger: logging.Logger,
-        avr_factory: Callable[
-            [
-                Config,
-                AVRState,
-                Callable[[str], None],
-                Callable[[], None],
-                logging.Logger,
-                Callable[[], None] | None,
-            ],
-            AVRConnection | VirtualAVRConnection,
-        ],
+        avr_factory: AVRFactory,
         runtime_state: RuntimeState,
     ) -> None:
         self.config = config
@@ -384,6 +392,7 @@ class DenonProxyServer:
         self.avr_state = AVRState()
         self.clients: set[ClientHandler] = set()
         self.avr: (AVRConnection | VirtualAVRConnection) | None = None
+        self._unanswered_tracker: UnansweredCommandTracker | None = None
         self._server: asyncio.Server | None = None
         self._json_api_server: asyncio.Server | None = None
         self._notify_web_state: Callable[[], None] = lambda: None
@@ -438,6 +447,8 @@ class DenonProxyServer:
 
     def _on_avr_response(self, message: str) -> None:
         """Called when the AVR sends a response."""
+        if self._unanswered_tracker:
+            self._unanswered_tracker.on_response(message)
         if _should_log_command_info(self.config, message):
             self.logger.info("AVR response: %s", message)
         else:
@@ -448,6 +459,8 @@ class DenonProxyServer:
 
     def _on_avr_disconnect(self) -> None:
         """Called when AVR disconnects or send attempted while disconnected - schedule reconnect (idempotent)."""
+        if self._unanswered_tracker:
+            self._unanswered_tracker.cancel_all_pending()
         # Push updated connection status to Web UI / SSE
         self.runtime_state.notify_web_state()
         if self._reconnect_task is not None and not self._reconnect_task.done():
@@ -509,6 +522,16 @@ class DenonProxyServer:
         else:
             self.runtime_state.avr_info = AVRInfo.virtual()
 
+        ua_n = int(self.config.get("avr_unanswered_log_suppress_after", 1))
+        self._unanswered_tracker = None
+        filtering = bool(self.config.get("dynamic_command_filtering", True))
+        if filtering and (self.config.get("avr_host") or "").strip():
+            self._unanswered_tracker = UnansweredCommandTracker(
+                self.logger,
+                suppress_after=ua_n,
+                response_timeout=float(self.config.get("avr_unanswered_response_timeout", 1.0)),
+            )
+
         self.avr = self._avr_factory(
             self.config,
             self.avr_state,
@@ -516,6 +539,7 @@ class DenonProxyServer:
             self._on_avr_disconnect,
             self.logger,
             self._on_avr_disconnect,  # on_send_while_disconnected: trigger same reconnect
+            self._unanswered_tracker,
         )
         connected = await self.avr.connect()
         if connected:
@@ -534,6 +558,7 @@ class DenonProxyServer:
                 config=self.config,
                 record_command=self.record_command,
                 broadcast_to_all=partial(self._broadcast, source="optimistic"),
+                unanswered_tracker=self._unanswered_tracker,
             )
 
         host = self.config["proxy_host"]

--- a/src/denon_proxy/proxy/core.py
+++ b/src/denon_proxy/proxy/core.py
@@ -19,7 +19,7 @@ from denon_proxy.avr.discovery import get_advertise_ip
 from denon_proxy.avr.info import AVRInfo
 from denon_proxy.avr.state import AVRState, volume_to_level
 from denon_proxy.avr.telnet_utils import parse_telnet_lines, telnet_line_to_bytes
-from denon_proxy.avr.unanswered_tracker import UnansweredCommandTracker
+from denon_proxy.avr.unanswered_tracker import UnansweredCommandTracker, is_avr_query_command
 from denon_proxy.command_log import (
     should_log_command_info as _should_log_command_info,
 )
@@ -294,7 +294,11 @@ class ClientHandler(asyncio.Protocol):
         client_ip = self._peername[0] if self._peername else "?"
         self.record_command(client_ip, command)
         client_display = self.config.client_display_for_log(client_ip)
-        if not (self.unanswered_tracker and self.unanswered_tracker.should_suppress(command)):
+        if not (
+            self.unanswered_tracker
+            and is_avr_query_command(command)
+            and self.unanswered_tracker.should_suppress(command)
+        ):
             if _should_log_command_info(self.config, command):
                 self.logger.info("Client %s command: %s", client_display, command)
             else:

--- a/src/denon_proxy/runtime/config.py
+++ b/src/denon_proxy/runtime/config.py
@@ -72,8 +72,9 @@ class Config(BaseModel, Mapping[str, Any]):
     client_activity_log_max_entries: int = Field(200, ge=1)
     # When true, query commands (e.g. PW?, MV?, SI?) are excluded from the activity log in the UI
     client_activity_log_hide_queries: bool = False
-    # Physical AVR: learn which telnet lines get no response and optionally stop logging them
-    # (uses avr_unanswered_log_suppress_after / avr_unanswered_response_timeout). Set false to disable.
+    # Physical AVR: learn which telnet *query* lines (ending with '?') get no response and optionally
+    # stop logging them (uses avr_unanswered_log_suppress_after / avr_unanswered_response_timeout).
+    # Set false to disable.
     dynamic_command_filtering: bool = True
     # Suppress client + "Sent to AVR" logs after this many unanswered sends per command (must be > 0).
     avr_unanswered_log_suppress_after: int = Field(1, gt=0)

--- a/src/denon_proxy/runtime/config.py
+++ b/src/denon_proxy/runtime/config.py
@@ -77,7 +77,7 @@ class Config(BaseModel, Mapping[str, Any]):
     # Set false to disable.
     dynamic_command_filtering: bool = True
     # Suppress client + "Sent to AVR" logs after this many unanswered sends per command (must be > 0).
-    avr_unanswered_log_suppress_after: int = Field(1, gt=0)
+    avr_unanswered_log_suppress_after: int = Field(3, gt=0)
     # Seconds to wait after each physical AVR send for a matching response line; if none arrives, that
     # send counts toward avr_unanswered_log_suppress_after (dynamic_command_filtering only).
     avr_unanswered_response_timeout: float = Field(1.0, ge=0.1, le=120.0)

--- a/src/denon_proxy/runtime/config.py
+++ b/src/denon_proxy/runtime/config.py
@@ -72,6 +72,14 @@ class Config(BaseModel, Mapping[str, Any]):
     client_activity_log_max_entries: int = Field(200, ge=1)
     # When true, query commands (e.g. PW?, MV?, SI?) are excluded from the activity log in the UI
     client_activity_log_hide_queries: bool = False
+    # Physical AVR: learn which telnet lines get no response and optionally stop logging them
+    # (uses avr_unanswered_log_suppress_after / avr_unanswered_response_timeout). Set false to disable.
+    dynamic_command_filtering: bool = True
+    # Suppress client + "Sent to AVR" logs after this many unanswered sends per command (must be > 0).
+    avr_unanswered_log_suppress_after: int = Field(1, gt=0)
+    # Seconds to wait after each physical AVR send for a matching response line; if none arrives, that
+    # send counts toward avr_unanswered_log_suppress_after (dynamic_command_filtering only).
+    avr_unanswered_response_timeout: float = Field(1.0, ge=0.1, le=120.0)
 
     # Optional/less common config keys
     ssdp_friendly_name: str | None = None

--- a/tests/unit/test_denon_proxy_config_validation.py
+++ b/tests/unit/test_denon_proxy_config_validation.py
@@ -147,6 +147,31 @@ INVALID_CONFIGS = [
         ["log_level", "string"],
         id="log_level_wrong_type",
     ),
+    pytest.param(
+        {"avr_unanswered_log_suppress_after": -1},
+        ["avr_unanswered_log_suppress_after"],
+        id="avr_unanswered_log_suppress_after_negative",
+    ),
+    pytest.param(
+        {"avr_unanswered_log_suppress_after": 0},
+        ["avr_unanswered_log_suppress_after"],
+        id="avr_unanswered_log_suppress_after_zero_invalid",
+    ),
+    pytest.param(
+        {"avr_unanswered_response_timeout": 0.05},
+        ["avr_unanswered_response_timeout"],
+        id="avr_unanswered_response_timeout_too_small",
+    ),
+    pytest.param(
+        {"avr_unanswered_response_timeout": 200.0},
+        ["avr_unanswered_response_timeout"],
+        id="avr_unanswered_response_timeout_too_large",
+    ),
+    pytest.param(
+        {"dynamic_command_filtering": 2},
+        ["dynamic_command_filtering", "bool"],
+        id="dynamic_command_filtering_wrong_type",
+    ),
 ]
 
 
@@ -213,6 +238,12 @@ VALID_BOUNDARY_CONFIGS = [
     pytest.param({"ssdp_friendly_name": " My AVR "}, id="ssdp_friendly_name_stripped"),
     pytest.param({"client_aliases": {}}, id="client_aliases_empty"),
     pytest.param({"client_aliases": {"192.168.1.5": "Living Room"}}, id="client_aliases_valid"),
+    pytest.param({"avr_unanswered_log_suppress_after": 1}, id="avr_unanswered_log_suppress_after_min"),
+    pytest.param({"avr_unanswered_log_suppress_after": 5}, id="avr_unanswered_log_suppress_after_positive"),
+    pytest.param({"avr_unanswered_response_timeout": 0.1}, id="avr_unanswered_response_timeout_min"),
+    pytest.param({"avr_unanswered_response_timeout": 120.0}, id="avr_unanswered_response_timeout_max"),
+    pytest.param({"dynamic_command_filtering": False}, id="dynamic_command_filtering_false"),
+    pytest.param({"dynamic_command_filtering": True}, id="dynamic_command_filtering_true"),
 ]
 
 
@@ -259,6 +290,9 @@ def test_maximal_valid_config_accepted() -> None:
         "client_activity_log": True,
         "client_activity_log_max_entries": 100,
         "client_activity_log_hide_queries": False,
+        "dynamic_command_filtering": True,
+        "avr_unanswered_log_suppress_after": 1,
+        "avr_unanswered_response_timeout": 1.0,
         "ssdp_friendly_name": "My Denon Proxy",
         "sources": {"CD": "CD", "HDMI1": "Apple TV"},
         "client_aliases": {"192.168.1.5": "HA"},

--- a/tests/unit/test_unanswered_tracker.py
+++ b/tests/unit/test_unanswered_tracker.py
@@ -9,6 +9,7 @@ import pytest
 
 from denon_proxy.avr.unanswered_tracker import (
     UnansweredCommandTracker,
+    is_avr_query_command,
     normalize_command_key,
     response_matches_command,
 )
@@ -16,6 +17,31 @@ from denon_proxy.avr.unanswered_tracker import (
 
 def test_normalize_command_key_collapses_whitespace() -> None:
     assert normalize_command_key("  PSIMAX  ?  ") == "PSIMAX ?"
+
+
+@pytest.mark.parametrize(
+    ("cmd", "expect"),
+    [
+        ("MV?", True),
+        ("  PSIMAX ? ", True),
+        ("MSSMART ?", True),
+        ("PWON", False),
+        ("PWON?", True),
+        ("", False),
+        ("  ", False),
+    ],
+)
+def test_is_avr_query_command(cmd: str, expect: bool) -> None:
+    assert is_avr_query_command(cmd) is expect
+
+
+@pytest.mark.asyncio
+async def test_non_query_never_tracked_or_suppressed() -> None:
+    log = logging.getLogger("test.unanswered.nonquery")
+    t = UnansweredCommandTracker(log, suppress_after=1, response_timeout=0.05)
+    t.note_sent("PWON")
+    await asyncio.sleep(0.08)
+    assert not t.should_suppress("PWON")
 
 
 def test_tracker_rejects_non_positive_suppress_after() -> None:

--- a/tests/unit/test_unanswered_tracker.py
+++ b/tests/unit/test_unanswered_tracker.py
@@ -9,6 +9,7 @@ import pytest
 
 from denon_proxy.avr.unanswered_tracker import (
     UnansweredCommandTracker,
+    command_stem,
     is_avr_query_command,
     normalize_command_key,
     response_matches_command,
@@ -68,6 +69,17 @@ def test_response_matches_command_cases(cmd: str, resp: str, expect: bool) -> No
     assert response_matches_command(key, resp) is expect
 
 
+@pytest.mark.parametrize("resp", ["", " ", "M"])
+def test_response_matches_command_rejects_short_or_empty_response(resp: str) -> None:
+    assert not response_matches_command(normalize_command_key("MV?"), resp)
+
+
+def test_command_stem_splits_question_from_first_token() -> None:
+    assert command_stem("PSIMAX ?") == "PSIMAX"
+    assert command_stem("MV?") == "MV"
+    assert command_stem("PWON") == "PWON"
+
+
 @pytest.mark.asyncio
 async def test_suppress_after_n_timeouts() -> None:
     log = logging.getLogger("test.unanswered.suppress")
@@ -122,3 +134,36 @@ async def test_suppression_cleared_when_matching_response_has_no_pending() -> No
     assert t.should_suppress("PSIMAX ?")
     t.on_response("PSIMAX50")
     assert not t.should_suppress("PSIMAX ?")
+
+
+@pytest.mark.asyncio
+async def test_unsolicited_unsuppress_prefers_longest_matching_stem() -> None:
+    """When several suppressed keys match one AVR line, drop the longest stem (most specific)."""
+    log = logging.getLogger("test.unanswered.longest_stem")
+    t = UnansweredCommandTracker(log, suppress_after=1, response_timeout=0.05)
+    t.note_sent("PS ?")
+    t.note_sent("PSIMAX ?")
+    await asyncio.sleep(0.08)
+    assert t.should_suppress("PS ?")
+    assert t.should_suppress("PSIMAX ?")
+    t.on_response("PSIMAX50")
+    assert not t.should_suppress("PSIMAX ?")
+    assert t.should_suppress("PS ?")
+
+
+@pytest.mark.asyncio
+async def test_should_suppress_uses_normalized_query_key() -> None:
+    log = logging.getLogger("test.unanswered.normalize")
+    t = UnansweredCommandTracker(log, suppress_after=1, response_timeout=0.05)
+    t.note_sent("PSIMAX ?")
+    await asyncio.sleep(0.08)
+    assert t.should_suppress("  psimax  ?  ")
+
+
+@pytest.mark.asyncio
+async def test_should_suppress_false_for_non_query_even_if_key_would_match() -> None:
+    """Defensive: non-query commands are never suppressed."""
+    log = logging.getLogger("test.unanswered.defensive")
+    t = UnansweredCommandTracker(log, suppress_after=1, response_timeout=0.05)
+    t._suppressed.add(normalize_command_key("MV?"))  # type: ignore[attr-defined]
+    assert not t.should_suppress("MV50")

--- a/tests/unit/test_unanswered_tracker.py
+++ b/tests/unit/test_unanswered_tracker.py
@@ -1,0 +1,98 @@
+"""Unit tests: AVR unanswered-command tracking and log suppression."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from denon_proxy.avr.unanswered_tracker import (
+    UnansweredCommandTracker,
+    normalize_command_key,
+    response_matches_command,
+)
+
+
+def test_normalize_command_key_collapses_whitespace() -> None:
+    assert normalize_command_key("  PSIMAX  ?  ") == "PSIMAX ?"
+
+
+def test_tracker_rejects_non_positive_suppress_after() -> None:
+    log = logging.getLogger("test.unanswered.reject")
+    with pytest.raises(ValueError, match="at least 1"):
+        UnansweredCommandTracker(log, suppress_after=0, response_timeout=0.05)
+
+
+@pytest.mark.parametrize(
+    ("cmd", "resp", "expect"),
+    [
+        ("MV?", "MV45", True),
+        ("MV?", "MVMAX MAX 60", False),
+        ("MVMAX?", "MVMAX MAX 60", True),
+        ("MS?", "MSSTEREO", True),
+        ("MS?", "MSSMART0", False),
+        ("MSSMART ?", "MSSMART0", True),
+        ("PSIMAX ?", "PSIMAX50", True),
+        ("PW?", "PWON", True),
+    ],
+)
+def test_response_matches_command_cases(cmd: str, resp: str, expect: bool) -> None:
+    key = normalize_command_key(cmd)
+    assert response_matches_command(key, resp) is expect
+
+
+@pytest.mark.asyncio
+async def test_suppress_after_n_timeouts() -> None:
+    log = logging.getLogger("test.unanswered.suppress")
+    t = UnansweredCommandTracker(log, suppress_after=2, response_timeout=0.05)
+    assert not t.should_suppress("PSIMAX ?")
+    t.note_sent("PSIMAX ?")
+    await asyncio.sleep(0.08)
+    assert not t.should_suppress("PSIMAX ?")
+    t.note_sent("PSIMAX ?")
+    await asyncio.sleep(0.08)
+    assert t.should_suppress("PSIMAX ?")
+
+
+@pytest.mark.asyncio
+async def test_matching_response_cancels_timeout() -> None:
+    log = logging.getLogger("test.unanswered.match")
+    t = UnansweredCommandTracker(log, suppress_after=1, response_timeout=0.2)
+    t.note_sent("MV?")
+    t.on_response("MV45")
+    await asyncio.sleep(0.25)
+    assert not t.should_suppress("MV?")
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_pending_does_not_count() -> None:
+    log = logging.getLogger("test.unanswered.cancel")
+    t = UnansweredCommandTracker(log, suppress_after=1, response_timeout=0.05)
+    t.note_sent("XYZ?")
+    t.cancel_all_pending()
+    await asyncio.sleep(0.08)
+    assert not t.should_suppress("XYZ?")
+
+
+@pytest.mark.asyncio
+async def test_suppression_cleared_when_response_matches_pending() -> None:
+    log = logging.getLogger("test.unanswered.unsuppress_pending")
+    t = UnansweredCommandTracker(log, suppress_after=1, response_timeout=0.05)
+    t.note_sent("PSIMAX ?")
+    await asyncio.sleep(0.08)
+    assert t.should_suppress("PSIMAX ?")
+    t.note_sent("PSIMAX ?")
+    t.on_response("PSIMAX50")
+    assert not t.should_suppress("PSIMAX ?")
+
+
+@pytest.mark.asyncio
+async def test_suppression_cleared_when_matching_response_has_no_pending() -> None:
+    log = logging.getLogger("test.unanswered.unsuppress_solo")
+    t = UnansweredCommandTracker(log, suppress_after=1, response_timeout=0.05)
+    t.note_sent("PSIMAX ?")
+    await asyncio.sleep(0.08)
+    assert t.should_suppress("PSIMAX ?")
+    t.on_response("PSIMAX50")
+    assert not t.should_suppress("PSIMAX ?")


### PR DESCRIPTION
Clients like to ask for things a lot -- sometimes things the AVR doesn't care to answer.

This adds a feature to dynamically filter log lines for queries the AVR has ignored a configurable number of times (3 by default).

If the AVR decides it wants to answer in the future, the command will start being logged again.