### PR TITLE
Faithfully broadcast what the AVR sends us

### DIFF
--- a/src/denon_proxy/avr/state.py
+++ b/src/denon_proxy/avr/state.py
@@ -127,18 +127,7 @@ class AVRState:
         """Return Denon telnet-format status lines for new clients and telnet sync."""
         lines = []
         if self.power:
-            # ZM (Zone Main) so HA denonavr receives power updates via telnet (it ignores PW).
-            # ZMSTANDBY uses parameter "STANDBY" which denonavr accepts; ZMOFF for compatibility.
-            # Order matches typical AVR telnet (ZMOFF before PW…) for standby/off.
-            if self.power == "ON":
-                lines.append(f"PW{self.power}")
-                lines.append("ZMON")
-            elif self.power in ("STANDBY", "OFF"):
-                lines.append("ZMOFF")
-                lines.append("ZMSTANDBY")
-                lines.append(f"PW{self.power}")
-            else:
-                lines.append(f"PW{self.power}")
+            lines.append(f"PW{self.power}")
         # When main zone is off, real AVRs typically do not emit MV/SI/MU/MS/MSSMART; omit them
         # so broadcasts and initial telnet dumps do not confuse clients with stale zone state.
         if self.power in ("STANDBY", "OFF"):

--- a/src/denon_proxy/avr/state.py
+++ b/src/denon_proxy/avr/state.py
@@ -128,10 +128,6 @@ class AVRState:
         lines = []
         if self.power:
             lines.append(f"PW{self.power}")
-        # When main zone is off, real AVRs typically do not emit MV/SI/MU/MS/MSSMART; omit them
-        # so broadcasts and initial telnet dumps do not confuse clients with stale zone state.
-        if self.power in ("STANDBY", "OFF"):
-            return "\r\n".join(lines) + "\r\n" if lines else ""
         if self.volume:
             lines.append(f"MV{self.volume}")
         if self.input_source:

--- a/src/denon_proxy/proxy/core.py
+++ b/src/denon_proxy/proxy/core.py
@@ -192,16 +192,7 @@ def state_and_config_updates_from_denonavr(d: Any) -> tuple[dict[str, Any], AVRI
 
 
 def avr_response_broadcast_lines(message: str) -> list[str]:
-    """
-    Return the list of lines to broadcast for an AVR response.
-    HA denonavr only processes ZM (not PW) for telnet updates; we add ZM equivalents
-    for power so the UI updates without needing an integration reload.
-    Standby/off lines follow typical AVR ordering (ZMOFF before PWSTANDBY) for picky clients.
-    """
-    if message == "PWON":
-        return [message, "ZMON"]
-    if "STANDBY" in message.upper():
-        return ["ZMOFF", "ZMSTANDBY", message]
+    """Return telnet lines to broadcast for an AVR response (faithful one-to-one relay)."""
     return [message]
 
 

--- a/tests/e2e/test_telnet_with_discovery.py
+++ b/tests/e2e/test_telnet_with_discovery.py
@@ -17,7 +17,7 @@ import pytest
 async def test_telnet_command_and_broadcast_on_discovery_stack(discovery_stack):
     """
     With proxy + discovery running, connect Telnet client, send PWSTANDBY then PWON;
-    assert client receives PWON and ZMON and proxy state becomes ON.
+    assert client receives PWON and proxy state becomes ON.
     """
     proxy, _ssdp, _http_servers = discovery_stack
     port = proxy.runtime_state.proxy_port or proxy.config["proxy_port"]
@@ -37,11 +37,10 @@ async def test_telnet_command_and_broadcast_on_discovery_stack(discovery_stack):
 
         writer.write(b"PWON\r")
         await writer.drain()
-        await asyncio.sleep(0.15)  # allow broadcast (PWON, ZMON) to be written
+        await asyncio.sleep(0.15)  # allow broadcast to be written
         response = await asyncio.wait_for(reader.read(4096), timeout=2.0)
         text = response.decode("utf-8", errors="replace")
         assert "PWON" in text
-        assert "ZMON" in text
         assert proxy.avr_state.power == "ON"
     finally:
         writer.close()

--- a/tests/integration/test_http_server_integration.py
+++ b/tests/integration/test_http_server_integration.py
@@ -305,9 +305,9 @@ async def test_http_refresh_request_state_broadcasts_to_telnet_clients(
             burst_b = await asyncio.wait_for(reader_b.read(4096), timeout=2.0)
             text_a = burst_a.decode("utf-8", errors="replace")
             text_b = burst_b.decode("utf-8", errors="replace")
-            # request_state pushes PW, ZM, MV, SI, MU, MS (and optionally MSSMART)
+            # request_state pushes PW, MV, SI, MU, MS (and optionally MSSMART)
             for label, text in (("A", text_a), ("B", text_b)):
-                assert "PW" in text or "ZM" in text, f"[{label}] Expected power lines in broadcast, got: {text!r}"
+                assert "PW" in text, f"[{label}] Expected power lines in broadcast, got: {text!r}"
                 assert "MV" in text, f"[{label}] Expected volume line in broadcast, got: {text!r}"
                 assert "SI" in text, f"[{label}] Expected input line in broadcast, got: {text!r}"
                 assert "MU" in text, f"[{label}] Expected mute line in broadcast, got: {text!r}"

--- a/tests/integration/test_telnet_virtual_avr.py
+++ b/tests/integration/test_telnet_virtual_avr.py
@@ -35,7 +35,7 @@ def integration_logger():
 @pytest.mark.asyncio
 async def test_telnet_pwon_receives_broadcast(integration_config, integration_logger):
     """
-    Put state in STANDBY then send PWON; assert client receives PWON and ZMON and state becomes ON.
+    Put state in STANDBY then send PWON; assert client receives PWON and state becomes ON.
     (Default state is already ON, so we establish STANDBY first to verify PWON actually changes state.)
     """
     server = DenonProxyServer(integration_config, integration_logger, create_avr_connection, RuntimeState())
@@ -54,7 +54,7 @@ async def test_telnet_pwon_receives_broadcast(integration_config, integration_lo
             port,
             [b"PWON"],
             {"power": "ON"},
-            ["PWON", "ZMON"],
+            ["PWON"],
         )
     finally:
         await server.stop()

--- a/tests/unit/test_avr_connection_virtual.py
+++ b/tests/unit/test_avr_connection_virtual.py
@@ -57,8 +57,8 @@ async def test_virtual_avr_request_state_pushes_status_dump_lines():
 
 
 @pytest.mark.asyncio
-async def test_virtual_avr_request_state_standby_pushes_power_lines_only():
-    """When STANDBY, get_status_dump omits MV/SI/etc.; request_state matches."""
+async def test_virtual_avr_request_state_standby_pushes_full_dump():
+    """When STANDBY, request_state still pushes all get_status_dump() lines."""
     state = AVRState()
     state.power = "STANDBY"
     state.volume = "45"
@@ -78,7 +78,7 @@ async def test_virtual_avr_request_state_standby_pushes_power_lines_only():
 
     expected = [line.strip() for line in state.get_status_dump().strip().splitlines() if line.strip()]
     assert recorded == expected
-    assert recorded == ["PWSTANDBY"]
+    assert recorded == ["PWSTANDBY", "MV45", "SIHDMI1", "MUOFF", "MSSTEREO"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_avr_connection_virtual.py
+++ b/tests/unit/test_avr_connection_virtual.py
@@ -14,7 +14,7 @@ from denon_proxy.avr.state import AVRState
 async def test_virtual_avr_request_state_pushes_status_dump_lines():
     """
     request_state() pushes each line from AVRState.get_status_dump() via on_response,
-    so the proxy receives the full status (PW, ZM, MV, SI, MU, MS, MSSMART) when ON.
+    so the proxy receives the full status (PW, MV, SI, MU, MS, MSSMART) when ON.
     """
     state = AVRState()
     state.power = "ON"
@@ -47,9 +47,8 @@ async def test_virtual_avr_request_state_pushes_status_dump_lines():
     assert recorded == expected, (
         f"on_response should be called with lines from get_status_dump(); got {recorded!r}, expected {expected!r}"
     )
-    # Sanity: we expect PW, ZM, MV, SI, MU, MS, and optionally MSSMART
+    # Sanity: we expect PW, MV, SI, MU, MS, and optionally MSSMART
     assert any(line.startswith("PW") for line in recorded)
-    assert any(line.startswith("ZM") for line in recorded)
     assert any(line.startswith("MV") for line in recorded)
     assert any(line.startswith("SI") for line in recorded)
     assert any(line.startswith("MU") for line in recorded)
@@ -79,7 +78,7 @@ async def test_virtual_avr_request_state_standby_pushes_power_lines_only():
 
     expected = [line.strip() for line in state.get_status_dump().strip().splitlines() if line.strip()]
     assert recorded == expected
-    assert recorded == ["ZMOFF", "ZMSTANDBY", "PWSTANDBY"]
+    assert recorded == ["PWSTANDBY"]
 
 
 @pytest.mark.asyncio
@@ -131,8 +130,8 @@ async def test_virtual_avr_send_command_empty_or_short_returns_true():
 
 
 @pytest.mark.asyncio
-async def test_virtual_avr_send_command_pwon_emits_pw_and_zm():
-    """send_command('PWON') emits both PW and ZM lines (PW/ZM cross-match branch)."""
+async def test_virtual_avr_send_command_pwon_emits_pwon_only():
+    """send_command('PWON') emits PWON only (status dump has no synthetic ZM)."""
     state = AVRState()
     state.power = "STANDBY"
     recorded = []
@@ -150,8 +149,7 @@ async def test_virtual_avr_send_command_pwon_emits_pw_and_zm():
     )
     await avr.connect()
     await avr.send_command("PWON")
-    assert "PWON" in recorded
-    assert "ZMON" in recorded
+    assert recorded == ["PWON"]
     assert state.power == "ON"
 
 

--- a/tests/unit/test_avr_state_core.py
+++ b/tests/unit/test_avr_state_core.py
@@ -132,17 +132,17 @@ def test_apply_command_and_get_status_dump_and_snapshot_restore():
     assert state.volume == snap["volume"]
 
 
-def test_get_status_dump_power_standby_pw_only():
-    """When power is STANDBY/OFF, status dump is PW only (no synthetic ZM lines)."""
+def test_get_status_dump_power_standby_includes_tracked_zone_state():
+    """STANDBY still serializes volume/input/mute/sound from tracked state (defaults unchanged)."""
     state = AVRState()
     state.power = "STANDBY"
     dump = state.get_status_dump()
     lines = [ln.strip() for ln in dump.strip().splitlines() if ln.strip()]
-    assert lines == ["PWSTANDBY"]
+    assert lines == ["PWSTANDBY", "MV50", "SICD", "MUOFF", "MSSTEREO"]
 
 
-def test_get_status_dump_standby_omits_volume_and_rest():
-    """When power is STANDBY, dump is PW line only even if internal state still has volume/input/etc."""
+def test_get_status_dump_standby_includes_volume_input_sound():
+    """When power is STANDBY, dump still includes other fields the proxy is tracking."""
     state = AVRState()
     state.power = "STANDBY"
     state.volume = "45"
@@ -150,7 +150,7 @@ def test_get_status_dump_standby_omits_volume_and_rest():
     state.sound_mode = "STEREO"
     dump = state.get_status_dump()
     lines = [ln.strip() for ln in dump.strip().splitlines() if ln.strip()]
-    assert lines == ["PWSTANDBY"]
+    assert lines == ["PWSTANDBY", "MV45", "SIHDMI1", "MUOFF", "MSSTEREO"]
 
 
 def test_apply_payload_normalizes_smart_select():

--- a/tests/unit/test_avr_state_core.py
+++ b/tests/unit/test_avr_state_core.py
@@ -132,23 +132,17 @@ def test_apply_command_and_get_status_dump_and_snapshot_restore():
     assert state.volume == snap["volume"]
 
 
-def test_get_status_dump_power_off_includes_zm():
-    """When power is STANDBY/OFF, status dump includes ZM lines and PW in AVR-typical order."""
+def test_get_status_dump_power_standby_pw_only():
+    """When power is STANDBY/OFF, status dump is PW only (no synthetic ZM lines)."""
     state = AVRState()
     state.power = "STANDBY"
     dump = state.get_status_dump()
-    assert "PWSTANDBY" in dump
-    assert "ZMSTANDBY" in dump
-    assert "ZMOFF" in dump
-    ordered = [ln.strip() for ln in dump.strip().splitlines() if ln.strip()]
-    zm_off_i = ordered.index("ZMOFF")
-    zm_sb_i = ordered.index("ZMSTANDBY")
-    pw_i = ordered.index("PWSTANDBY")
-    assert zm_off_i < zm_sb_i < pw_i
+    lines = [ln.strip() for ln in dump.strip().splitlines() if ln.strip()]
+    assert lines == ["PWSTANDBY"]
 
 
 def test_get_status_dump_standby_omits_volume_and_rest():
-    """When power is STANDBY, dump is power/ZM only even if internal state still has volume/input/etc."""
+    """When power is STANDBY, dump is PW line only even if internal state still has volume/input/etc."""
     state = AVRState()
     state.power = "STANDBY"
     state.volume = "45"
@@ -156,7 +150,7 @@ def test_get_status_dump_standby_omits_volume_and_rest():
     state.sound_mode = "STEREO"
     dump = state.get_status_dump()
     lines = [ln.strip() for ln in dump.strip().splitlines() if ln.strip()]
-    assert lines == ["ZMOFF", "ZMSTANDBY", "PWSTANDBY"]
+    assert lines == ["PWSTANDBY"]
 
 
 def test_apply_payload_normalizes_smart_select():

--- a/tests/unit/test_proxy_core_helpers.py
+++ b/tests/unit/test_proxy_core_helpers.py
@@ -271,13 +271,13 @@ def test_record_command_stores_queries_when_hide_queries_false():
 
 
 def test_avr_response_broadcast_lines_pwon():
-    assert avr_response_broadcast_lines("PWON") == ["PWON", "ZMON"]
+    assert avr_response_broadcast_lines("PWON") == ["PWON"]
 
 
 def test_avr_response_broadcast_lines_standby():
-    assert avr_response_broadcast_lines("PWSTANDBY") == ["ZMOFF", "ZMSTANDBY", "PWSTANDBY"]
-    assert avr_response_broadcast_lines("PWSTANDBY ") == ["ZMOFF", "ZMSTANDBY", "PWSTANDBY "]
-    assert avr_response_broadcast_lines("PWstandby") == ["ZMOFF", "ZMSTANDBY", "PWstandby"]
+    assert avr_response_broadcast_lines("PWSTANDBY") == ["PWSTANDBY"]
+    assert avr_response_broadcast_lines("PWSTANDBY ") == ["PWSTANDBY "]
+    assert avr_response_broadcast_lines("PWstandby") == ["PWstandby"]
 
 
 def test_avr_response_broadcast_lines_other():


### PR DESCRIPTION
The order/timing of our altered broadcasts were causing power sync issues with the UC Remote 3.  

Removing these alterations fixed the behavior of the remote and simplifies the code.