### PR TITLE
Fix: UC remote power desync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ htmlcov/
 # IDE
 .idea/
 .vscode/
+**/.DS_Store
 *.swp
 *.swo
 uv.lock

--- a/docs/UC-POWER-BUG/UC_REMOTE_POWER_ISSUE_HANDOFF.md
+++ b/docs/UC-POWER-BUG/UC_REMOTE_POWER_ISSUE_HANDOFF.md
@@ -1,0 +1,169 @@
+# Handoff: UC Remote 3 power control via denon-proxy
+
+This document summarizes **observed behavior**, **evidence**, and **system context** so another reviewer can analyze the issue without inheriting prior hypotheses about root cause.
+
+---
+
+## Role of denon-proxy
+
+Repository: **[https://github.com/forsethc/denon-proxy](https://github.com/forsethc/denon-proxy)** — **production** runs Git branch **`fix/clean-avr-commands`** (see **Source of truth** below).
+
+Denon AV receivers typically allow **one** Telnet (TCP) session to the control port. The proxy:
+
+- Listens for **multiple** inbound Telnet clients (e.g. Home Assistant, Unfolded Circle “UC Remote 3”).
+- Maintains **one** outbound Telnet session to the physical AVR.
+- Forwards client commands to the AVR (serialized on the single AVR link).
+- **Broadcasts** each line received from the AVR to **all** currently connected clients.
+- Tracks internal AVR-like state (power, volume, input, mute, etc.) and, when a new client connects, sends an immediate **status snapshot** to that client (implementation: `AVRState.get_status_dump()` in `src/denon_proxy/avr/state.py`, invoked from `ClientHandler.connection_made` in `src/denon_proxy/proxy/core.py`).
+- Optional **optimistic** application of client commands to internal state before/after forwarding, with configurable delay and broadcast of derived status lines (`ClientHandler._handle_command_async`, `_broadcast_state` in `core.py`).
+
+Configuration surface includes HTTP API (e.g. `POST /api/refresh` triggers `AVRConnection.request_state()`, which sends a fixed sequence of query commands such as `PW?`, `MV?`, `ZM?`, etc., to the physical AVR).
+
+---
+
+## Erratic behavior reported
+
+1. **UC Remote 3** (Unfolded Circle Remote, Denon AVR integration) sometimes **fails to turn the receiver on** when the user expects it to. While this failure mode is present, **the proxy logs show no corresponding `Client … command: PWON`** (INFO-level line) from the UC Remote for those power-on attempts—the command simply never appears in journald as originating from that client, even though the user is pressing power on.
+2. **Power-off** (`PWSTANDBY` in proxy logs) **continues to appear** in logs when the user powers off.
+3. **Home Assistant** (second client; same proxy) **continues to control power successfully** when UC Remote misbehaves.
+4. **Restarting only the denon-proxy service** (not the UC device or the AVR) **restores** normal UC Remote power-on behavior for a time.
+5. **Web UI “Refresh from AVR”** (HTTP **`POST /api/refresh`**, which triggers `request_state()` / the usual `PW?`, `MV?`, **`ZM?`**, … query sequence to the physical AVR and broadcasts answers to connected Telnet clients) **does not** resolve the UC Remote power / sync problem when this failure mode is active—**unlike** restarting the `denon-proxy` service (operator observation).
+
+**Configuration note:** The same class of UC Remote power-on failures has been observed with **`optimistic_state` enabled and disabled** in denon-proxy config. Analysts should not assume the bug is confined to optimistic broadcasts alone.
+
+---
+
+## Evidence: proxy logs (journal), command filtering
+
+Example extraction pattern used on the deployment host:
+
+```bash
+journalctl -u denon-proxy --since "7 days ago" | grep -vi "debug" | grep -v "?" | grep "command: PW"
+```
+
+That pipeline **removes** lines containing `?` (so **query** traffic such as `PW?` is excluded from the excerpt).
+
+### Pattern observed over ~7 days
+
+- **Home Assistant** (`10.0.1.5`): `PWON` and `PWSTANDBY` appear when expected.
+- **UC Remote 3** (`10.0.3.10`):
+  - For a period, **both** `PWON` and `PWSTANDBY` appear, sometimes **two `PWON` lines within one second**.
+  - Later in the same period, **only** `PWSTANDBY` appears from UC Remote; **no** `PWON` lines appear in the filtered log **even when the user attempts to turn the unit on**.
+- **Process restarts** appear as changes in the logged `python[PID]` (deployments or service restarts correlate with renewed `PWON` from UC Remote in subsequent log segments).
+
+Representative log lines (as provided by the operator; abbreviated):
+
+```
+Mar 29 … Client UC Remote 3 (10.0.3.10) command: PWON
+Mar 29 … Client UC Remote 3 (10.0.3.10) command: PWON
+…
+Apr 01 … Client UC Remote 3 (10.0.3.10) command: PWSTANDBY
+Apr 01 … (no UC PWON in this stretch; multiple PWSTANDBY only)
+…
+Apr 02 … Client Home Assistant (10.0.1.5) command: PWON
+…
+Apr 04 … Client UC Remote 3 (10.0.3.10) command: PWSTANDBY / PWON patterns resume after service restarts in the log
+```
+
+**Interpretation note for the analyst:** absence of `PWON` in this grep means **either** the client did not emit `PWON`, **or** the proxy did not treat/process a line as a logged command (e.g. parsing, validation, logging level, or line format). The logs alone do not distinguish those without additional instrumentation or packet capture.
+
+---
+
+## Evidence: UC Remote connect/disconnect cadence
+
+The proxy logs **per-telnet-client** connect/disconnect. UC Remote does not keep a permanent Telnet session; it disconnects and reconnects regularly (e.g. device sleep/wake).
+
+Example sequence (single day, same proxy process):
+
+```
+Client disconnected: UC Remote 3 (10.0.3.10) (remaining: 1)
+Client connected: UC Remote 3 (10.0.3.10) (total: 2)
+```
+
+So from the **proxy’s perspective**, each wake cycle is already a **new** TCP connection and a new `ClientHandler`; `connection_made` runs again and sends the current `get_status_dump()` snapshot to that client.
+
+---
+
+## Source of truth: use GitHub (and deployed revisions), not informal local trees
+
+Cross-repo analysis should rely on **authoritative sources**: the repositories and **exact commits / release tags** that match what runs in production. Ad-hoc or partial local checkouts (any machine) can be **wrong branch, wrong fork, or wrong pin** and should **not** be treated as evidence about upstream behavior.
+
+1. **Confirm what is deployed** where possible: UC Remote integration version or channel, HA core version, `denon-proxy` package/git revision on the Pi/host, and whether the AVR integration points at the proxy or at the receiver.
+2. **Open the same revision on GitHub** (or equivalent tagged release artifacts) when reading `requirements.txt`, library code, and HA components.
+3. **Pinned Python dependencies** must be taken from the integration’s **`requirements.txt` at the Git revision that matches the device**, not from another checkout.
+
+### Unfolded Circle Denon AVR integration (“UC Remote” driver)
+
+- **Repository:** [https://github.com/unfoldedcircle/integration-denonavr](https://github.com/unfoldedcircle/integration-denonavr)
+- **Dependency pins** (example from **`requirements.txt` on `main` at time this doc was refreshed; always re-read live on GitHub for the branch/tag you care about):  
+  [https://github.com/unfoldedcircle/integration-denonavr/blob/main/requirements.txt](https://github.com/unfoldedcircle/integration-denonavr/blob/main/requirements.txt)
+
+Current pinned `denonavr` install (VCS line from that file):
+
+```text
+denonavr@git+https://github.com/henrikwidlund/denonavr.git@7c77360db681f3c3f8c27bcf53f318adabee37a0
+```
+
+For UC behavior, the relevant **`denonavr` source is that repository at commit `7c77360db681f3c3f8c27bcf53f318adabee37a0`** (until the integration bumps the pin). Direct link:  
+[https://github.com/henrikwidlund/denonavr/tree/7c77360db681f3c3f8c27bcf53f318adabee37a0](https://github.com/henrikwidlund/denonavr/tree/7c77360db681f3c3f8c27bcf53f318adabee37a0)
+
+Other dependencies from the same file: `pyee~=13.0.1`, `ucapi==0.5.2` (verify on GitHub when analyzing).
+
+### denonavr (historical upstream, reference only)
+
+- **Repository:** [https://github.com/olivergrant/denonavr](https://github.com/olivergrant/denonavr)  
+  Many forks diverge; **the UC integration does not necessarily track this tree** for runtime behavior—compare only when investigating shared ancestry or porting fixes.
+
+### Home Assistant Denon integration (comparison client)
+
+- **Repository:** [https://github.com/home-assistant/core](https://github.com/home-assistant/core)  
+- **Typical path:** `homeassistant/components/denon/`  
+- Use the **tag matching the operator’s Home Assistant release** (e.g. `2024.x.y`) or `dev` if explicitly analyzing tip; do not assume an unlabeled local `core` checkout matches production.
+
+### denon-proxy
+
+- **Repository:** [https://github.com/forsethc/denon-proxy](https://github.com/forsethc/denon-proxy)  
+- **Production deployment (operator):** branch **`fix/clean-avr-commands`** — [https://github.com/forsethc/denon-proxy/tree/fix/clean-avr-commands](https://github.com/forsethc/denon-proxy/tree/fix/clean-avr-commands). Correlate logs and symptoms with the **commit** at the tip of that branch (or the exact revision installed on the proxy host), not only `main`.
+
+---
+
+## Component map (for navigation)
+
+| Component | Role |
+|-----------|------|
+| **denon-proxy** | Multiplexes Telnet clients to one AVR; logs `Client … command:` for lines accepted from clients; relays AVR lines. |
+| **Unfolded Circle Denon AVR integration** | Python integration on UC Remote; Telnet/HTTP to AVR **or** to proxy as host; pins `denonavr` and `ucapi` per its `requirements.txt`. |
+| **henrikwidlund/denonavr (pinned commit)** | Library used by that integration at runtime for UC-controlled behavior. |
+| **olivergrant/denonavr** | Historical upstream reference. |
+| **Home Assistant `denon` component** | Alternative client; may use different command patterns; compare at the HA version in use. |
+
+---
+
+## Facts about proxy client command path (for reproduction / instrumentation)
+
+- Incoming bytes from a Telnet client are split into lines in `parse_telnet_lines` (`src/denon_proxy/avr/telnet_utils.py`).
+- Each non-empty decoded line is passed to `ClientHandler._handle_command` in `core.py`.
+- Invalid lines (per `_is_valid_client_command`, e.g. certain control characters) are rejected with **debug** logging, not necessarily **info** `command:` logs.
+- Client `command:` **info** logging is subject to `log_command_groups_info` in config (`command_log.py`); power-related groups must be enabled for `PWON` / `PWSTANDBY` to appear at INFO.
+
+---
+
+## What this handoff intentionally omits
+
+- Causal theories (protocol negotiation, optimistic vs AVR-relay semantics, client internal power state, idempotency of library methods, etc.).
+- Presumed fixes.
+
+Those should be derived from independent analysis of the **GitHub revisions above**, captures of raw bytes on the wire if possible, and UC integration / `denonavr` traces at appropriate log levels.
+
+---
+
+## Suggested next steps for an analyst
+
+1. Confirm **exact** Telnet payloads from UC Remote at the proxy when power-on **fails** (tcpdump / proxy debug logging of raw client reads).
+2. Compare behavior when UC points **directly** at the AVR (single client) vs **via** proxy.
+3. Compare **`henrikwidlund/denonavr` at the integration’s pinned commit** plus the integration’s Telnet usage with **Home Assistant’s `denon` component at the operator’s HA version** for the same operations.
+4. Correlate proxy **service restart** with **AVR-side** connection teardown (proxy reconnects to AVR on start) vs **client-only** reconnect patterns.
+
+---
+
+*Document purpose: external handoff. Use GitHub (and deployment-matching revisions) as the analysis source of truth. **denon-proxy** production runs branch **`fix/clean-avr-commands`** on [forsethc/denon-proxy](https://github.com/forsethc/denon-proxy). The `denonavr` Git commit and `ucapi` version above match [unfoldedcircle/integration-denonavr `main` `requirements.txt`](https://github.com/unfoldedcircle/integration-denonavr/blob/main/requirements.txt) as of the last edit of this file—re-verify before attributing bugs upstream.*

--- a/docs/UC-POWER-BUG/agent-analyses/README.md
+++ b/docs/UC-POWER-BUG/agent-analyses/README.md
@@ -1,0 +1,6 @@
+# Agent analyses (comparison folder)
+
+This directory holds **opinionated** writeups from individual agents: conclusions, ranked hypotheses, code pointers, and suggested next steps.
+
+- **Neutral fact handoff** (no prejudged cause): `docs/UC_REMOTE_POWER_ISSUE_HANDOFF.md`
+- **Agent analyses**: name files in a consistent pattern, e.g. `cursor-agent-2026-04-04.md`, `codex-agent-2026-04-05.md`, so results are easy to diff.

--- a/docs/UC-POWER-BUG/agent-analyses/claude-4.6-opus-2026-04-05.md
+++ b/docs/UC-POWER-BUG/agent-analyses/claude-4.6-opus-2026-04-05.md
@@ -1,0 +1,191 @@
+# Agent analysis: UC Remote power-on failures via denon-proxy (revision 2)
+
+**Agent:** claude-4.6-opus (via Cursor)
+**Date:** 2026-04-05 (revised from earlier same-day analysis)
+**Scope:** Independent code review of denon-proxy, henrikwidlund/denonavr at the integration's pinned commit (`7c77360`), unfoldedcircle/integration-denonavr (`main`), and Home Assistant's `denon` component (`dev`). All library analysis uses GitHub sources, not local checkouts. This revision incorporates the updated handoff (symptoms 5 and the optimistic_state configuration note) and a critical finding about the `_power_callback` zone guard that the first revision missed.
+
+---
+
+## Sources reviewed
+
+| Component | Source | Revision |
+|-----------|--------|----------|
+| denon-proxy | local workspace | `fix/clean-avr-commands` HEAD (production branch per handoff) |
+| henrikwidlund/denonavr | [GitHub](https://github.com/henrikwidlund/denonavr/tree/7c77360db681f3c3f8c27bcf53f318adabee37a0) | `7c77360` (pinned by integration `requirements.txt`) |
+| integration-denonavr | [GitHub](https://github.com/unfoldedcircle/integration-denonavr/blob/main/intg-denonavr/avr.py) | `main` |
+| HA denon component | [GitHub](https://github.com/home-assistant/core/blob/dev/homeassistant/components/denon/media_player.py) | `dev` |
+
+---
+
+## Symptoms restated (updated from handoff)
+
+1. UC Remote 3 stops producing `PWON` in proxy logs; `PWSTANDBY` continues appearing.
+2. Home Assistant controls power successfully through the same proxy throughout.
+3. Restarting only the denon-proxy service temporarily restores UC power-on.
+4. The failure develops within a single proxy process lifetime.
+5. **Web UI "Refresh from AVR"** (`POST /api/refresh`, which sends `PW?`, `ZM?`, etc. to the real AVR and broadcasts responses) does **not** resolve the problem.
+6. The bug occurs with `optimistic_state` **both enabled and disabled**.
+
+---
+
+## Root cause: `_power_callback` is dead code for single-zone receivers
+
+**Confidence: High — structurally guaranteed by the code at the pinned commit**
+
+This is the primary finding. The `_power` field that gates `async_power_on()` is **never updated from telnet events** for single-zone receivers, due to a zone-check mismatch in the callback dispatch chain. This makes `_power` freeze at its initial HTTP-fetched value once telnet becomes healthy, creating a permanent deadlock.
+
+### The evidence chain
+
+**Step 1: The receiver is single-zone.** The proxy logs show UC sending `PWSTANDBY` (not `ZMOFF`). From `foundation.py` `_register_callbacks()` (lines 790-802 at pinned commit):
+
+```python
+def _register_callbacks(self):
+    power_event = "ZM"
+    ...
+    elif self.zones == 1:
+        power_event = "PW"
+        self.telnet_commands = self.telnet_commands._replace(
+            command_power_on="PWON", command_power_standby="PWSTANDBY"
+        )
+    self.telnet_api.register_callback(power_event, self._power_callback)
+```
+
+The `PWSTANDBY` command in logs means `zones == 1` triggered this branch — otherwise denonavr would send `ZMOFF`.
+
+**Step 2: `PW` events arrive with `zone = ALL_ZONES`.** From `const.py` (line 1167-1183):
+
+```python
+ALL_ZONE_TELNET_EVENTS = {
+    "DIM", "HD", "ILB", "NS", "NSA", "NSE", "MN",
+    "PW",   # ← PW is here
+    "RM", "SY", "TF", "TM", "TP", "TR", "UG",
+}
+```
+
+And from `api.py` `_process_event()` (lines 907-910):
+
+```python
+zone = MAIN_ZONE          # "Main"
+if event in ALL_ZONE_TELNET_EVENTS:
+    zone = ALL_ZONES       # "All"
+```
+
+So every `PWON` / `PWSTANDBY` telnet message → `zone = "All"`.
+
+**Step 3: The zone guard in `_power_callback` never passes.** From `foundation.py` (line 472-475):
+
+```python
+def _power_callback(self, zone: str, _event: str, parameter: str) -> None:
+    if self.zone == zone and parameter in POWER_STATES:
+        self._power = parameter
+```
+
+`self.zone = "Main"` (MAIN_ZONE). The check `"Main" == "All"` is always **False**. `_power` is never written.
+
+**Step 4: HTTP updates are skipped once telnet is healthy.** From the UC integration's `avr.py` `async_update_receiver_data()` (lines 682-687):
+
+```python
+if (telnet_is_healthy := self._telnet_healthy) and self._telnet_was_healthy:
+    if force:
+        await receiver.async_update()
+        ...
+    self._notify_updated_data()
+    return  # ← skips async_update() entirely
+```
+
+Once telnet has been healthy across two consecutive update cycles, `async_update()` (the HTTP call that updates `_power`) is permanently skipped. The system assumes telnet callbacks will keep `_power` current — but per Step 3, they cannot.
+
+**Step 5: `_power` freezes, and `async_power_on()` silently no-ops.** From `foundation.py` (lines 1596-1599):
+
+```python
+async def async_power_on(self) -> None:
+    if self._power == "ON":
+        return  # ← no telnet write, no proxy log, nothing
+```
+
+`_power` was set to `"ON"` during the initial HTTP update when the receiver was on. It never changes again. Every subsequent `async_power_on()` call silently returns, regardless of actual AVR state.
+
+### Why this fits every symptom
+
+| Symptom | Explanation |
+|---------|-------------|
+| UC `PWON` disappears from proxy logs | `async_power_on()` returns before writing to telnet → nothing reaches proxy |
+| UC `PWSTANDBY` still appears | `async_power_off()` guards on `_power == "OFF"`, which is never true (stuck on `"ON"`), so it always proceeds and sends `PWSTANDBY` |
+| HA continues working | HA's `denon` component sends `PWON` via raw telnet (`self.telnet_command("PWON")`) — no `_power` guard |
+| Proxy restart fixes it | Restart drops all TCP sessions → UC's denonavr loses telnet → `_telnet_was_healthy` resets → next update calls `async_update()` (HTTP) → `_power` refreshed from real AVR state |
+| **`POST /api/refresh` does NOT fix it** | Refresh sends `PW?` to AVR, AVR responds `PWSTANDBY`, proxy broadcasts it to UC. But `PWSTANDBY` is a `PW` event → `zone = ALL_ZONES` → zone guard fails → **`_power` still not updated**. This symptom is the strongest discriminator: it rules out any theory that depends on the proxy not providing fresh state. |
+| Bug occurs with optimistic_state on or off | The root cause is in denonavr's callback dispatch, not in the proxy's optimistic broadcasting. Optimistic state is irrelevant. |
+
+---
+
+## What my first revision got wrong
+
+My previous analysis centered on Theory 1 (optimistic broadcasts cause UC to believe AVR is already ON) and Theory 2 (PW vs ZM mismatch for multi-zone receivers). Both were plausible but missed the actual mechanism:
+
+1. **I assumed the PW/ZM split only mattered for multi-zone receivers.** In fact, the zone guard bug means `_power` is broken for single-zone receivers too — and the log evidence (`PWSTANDBY` not `ZMOFF`) indicates this is a single-zone receiver.
+
+2. **I treated optimistic state as a compounding factor.** The updated handoff explicitly states the bug occurs with optimistic_state disabled, ruling this out as a contributing cause.
+
+3. **I didn't trace the `_process_event` → `_run_callbacks` zone assignment.** The `ALL_ZONE_TELNET_EVENTS` → `zone = ALL_ZONES` assignment is the critical link. Without reading `const.py`'s `ALL_ZONE_TELNET_EVENTS` set and cross-referencing it with `_process_event`'s zone logic, the zone guard mismatch is invisible.
+
+4. **I didn't account for why `POST /api/refresh` fails to fix it.** This new symptom conclusively eliminates theories based on "the proxy doesn't provide enough state." The proxy does provide fresh `PWSTANDBY` from the real AVR — denonavr just can't process it due to the zone guard bug.
+
+---
+
+## Secondary concern: multi-zone receivers may have a related but distinct failure mode
+
+For multi-zone receivers (`zones > 1`), `_power_callback` is registered on `ZM`, and `ZM` events are **not** in `ALL_ZONE_TELNET_EVENTS`. So `ZM` events arrive with `zone = MAIN_ZONE`, and the guard `self.zone == zone` → `"Main" == "Main"` passes correctly. `_power` **does** update from `ZM` telnet events in the multi-zone case.
+
+However, the proxy's `get_status_dump()` only emits `PW…` lines, never `ZM…`. If a multi-zone UC reconnects and receives only `PW` status, `_power` is not updated (no `ZM` event). The `_async_trigger_updates()` query sequence includes `ZM?` (api.py line 660), so a fresh telnet connect should eventually populate `_power` — but there may be a timing window where the status dump's `PWON` makes the integration think the receiver is on before `ZM?` completes.
+
+This is a weaker failure mode than the single-zone bug and may not apply to this specific operator (whose logs suggest single-zone). But adding `ZMON`/`ZMOFF` to `get_status_dump()` would be a defensive improvement.
+
+---
+
+## Recommendations
+
+### In denonavr (pinned fork — highest priority)
+
+1. **Fix `_power_callback` zone guard to accept `ALL_ZONES`:**
+
+   ```python
+   def _power_callback(self, zone: str, _event: str, parameter: str) -> None:
+       if (self.zone == zone or zone == ALL_ZONES) and parameter in POWER_STATES:
+           self._power = parameter
+   ```
+
+   This is the minimal fix. It allows `PW` events (which always arrive with `zone = ALL_ZONES`) to update `_power` for single-zone receivers where the callback is registered on `PW`.
+
+2. **Remove or weaken the `_power == "ON"` guard in `async_power_on()`:** `PWON`/`ZMON` is idempotent on Denon receivers. The guard creates fragile coupling for no benefit.
+
+### In denon-proxy (this repo — defensive)
+
+3. **Emit `ZMON`/`ZMOFF` in `get_status_dump()` alongside `PW…`:** Helps multi-zone receivers whose `_power_callback` (correctly) listens on `ZM`.
+
+4. **Verify IAC stripping fix is in the deployed revision on `fix/clean-avr-commands`.**
+
+### Diagnostics
+
+5. **Confirm single-zone:** Check denonavr setup logs for `zones` value, or inspect `DeviceZones` in the AVR's Deviceinfo.xml.
+
+6. **Instrument `_power` in denonavr:** Add a debug log at the top of `async_power_on()` showing `self._power`. If it reports `"ON"` when the AVR is in standby, the zone guard bug is confirmed as the active mechanism.
+
+7. **Reproduce without the proxy:** Point UC directly at the AVR. If the bug still occurs when HA turns off via `PWSTANDBY` and UC can't turn on, the bug is entirely in denonavr and is proxy-independent. This would be the strongest confirmation.
+
+---
+
+## Comparison with other analyses
+
+| Analysis | Primary theory | Zone guard bug? | Handles symptom 5 (refresh doesn't fix)? |
+|----------|---------------|-----------------|-------------------------------------------|
+| cursor-agent-2026-04-04 | IAC corruption + PW/ZM mismatch | No | N/A (predates symptom) |
+| claude-4.6-opus rev 1 | PW/ZM mismatch (multi-zone) + optimistic state | No | No |
+| codex-agent-2026-04-05 | False optimistic state after AVR disconnect | No | No |
+| cursor-claude-sonnet-4-5 | Zone guard dead code + HTTP skip | **Yes** | **Yes** |
+| **This revision** | Zone guard dead code + HTTP skip (confirmed) | **Yes** | **Yes** |
+
+The Sonnet analysis correctly identified the zone guard bug. This revision independently verifies the mechanism by tracing the full dispatch chain through `const.py` → `api.py` → `foundation.py`, and explains why `POST /api/refresh` cannot fix the problem (the fresh AVR responses still go through the broken `_process_event` → `_power_callback` path).
+
+---
+
+*All library code references verified against GitHub at the revisions listed in the table above. `PW` ∈ `ALL_ZONE_TELNET_EVENTS` verified at const.py line 1175; `_process_event` zone assignment at api.py lines 907-910; `_power_callback` guard at foundation.py line 473; `async_power_on` guard at foundation.py line 1598. Re-verify `requirements.txt` pins before attributing behavior to upstream libraries.*

--- a/docs/UC-POWER-BUG/agent-analyses/codex-agent-2026-04-05.md
+++ b/docs/UC-POWER-BUG/agent-analyses/codex-agent-2026-04-05.md
@@ -1,0 +1,200 @@
+# Agent analysis: UC Remote power issue via denon-proxy
+
+**Agent:** Codex  
+**Date:** 2026-04-05  
+**Scope:** Updated analysis from the latest `docs/UC_REMOTE_POWER_ISSUE_HANDOFF.md`, using the deployed `denon-proxy` branch named in that handoff plus the GitHub-pinned UC dependencies it references.
+
+---
+
+## Executive summary
+
+The new handoff materially changes my prior ranking.
+
+Two fresh facts are especially important:
+
+1. The same failure has been observed with **`optimistic_state` both enabled and disabled**.
+2. **`POST /api/refresh` does not recover the problem**, while a full `denon-proxy` service restart does.
+
+Because of those two points, I no longer think a proxy-only stale optimistic state is the best primary theory.
+
+My current leading explanation is that the UC stack itself gets into a **stale or poisoned power/session state** in which it stops emitting `PWON` at all, even though it can still emit `PWSTANDBY`. The proxy restart likely helps not because of the refresh queries it performs, but because it forces a **hard peer-side socket reset and full reconnect path** in the UC telnet client/library.
+
+---
+
+## Ranked theories
+
+### 1. Most likely cause: UC integration / pinned `denonavr` gets into a stale state where `PWON` is suppressed before it ever reaches the proxy
+
+This is now my top theory because it best matches the updated handoff's strongest evidence:
+
+- when the bug is active, the proxy logs show **no UC `PWON` line at all**
+- UC can still produce `PWSTANDBY`
+- Home Assistant still controls power successfully
+- `POST /api/refresh` does not fix it
+- a full proxy restart does fix it temporarily
+
+The GitHub-pinned UC stack still has send-suppression behavior:
+
+- `denonavr.async_power_on()` returns immediately if internal `_power == "ON"`
+- `denonavr.async_power_off()` returns immediately if internal `_power == "OFF"`
+
+The UC integration also keeps long-lived receiver state and expected state across its own reconnect logic, and it has explicit workaround code for state-reporting mismatch.
+
+That creates a plausible failure mode:
+
+1. UC's internal power state becomes wrong or stale.
+2. A user presses power on.
+3. The UC stack decides the receiver is already on and does not actually send `PWON`.
+4. The proxy never logs `Client ... command: PWON` because nothing was sent.
+
+Why this theory moved to the top:
+
+- It directly explains the missing proxy-side `PWON` log lines.
+- It remains compatible with `PWSTANDBY` still appearing.
+- It is consistent with `optimistic_state` being irrelevant.
+- It is consistent with `POST /api/refresh` being insufficient if the UC-side session/state machine is already wedged or not incorporating the refresh correctly.
+
+Confidence: **high**
+
+---
+
+### 2. Strong companion theory: the UC telnet session or callback machinery gets wedged, and only a hard peer disconnect fully resets it
+
+The pinned UC stack has a meaningful distinction between:
+
+- routine updates / telnet health checks
+- telnet reconnect
+- full integration connect/disconnect lifecycle
+
+Relevant code behavior:
+
+- the integration keeps `_expected_state` and receiver objects across reconnects
+- `power_on()` calls `_receiver.async_power_on()` and then only schedules an update if telnet is not healthy
+- the telnet layer has its own `connected` / `healthy` state, keepalive, reconnect task, send confirmation event, and callback registration
+
+This makes the handoff's new restart-vs-refresh fact especially important:
+
+- `POST /api/refresh` proves that **fresh AVR state queries alone are not sufficient**
+- service restart does more than refresh: it tears down the client-facing socket from the proxy side and forces the UC stack through a harder reconnect path
+
+So I think there is a real possibility that the UC-side telnet protocol/callback state gets into a bad state where:
+
+- power-on sends are suppressed or never reach the transport
+- ordinary state refreshes do not unwind the condition
+- only a full peer disconnect from the proxy side recovers the session
+
+This is distinct from theory 1 but compatible with it; theory 1 is about stale power state, while this one is about a wider poisoned telnet/session state.
+
+Confidence: **medium-high**
+
+---
+
+### 3. Lower-confidence proxy-side theory: a `PWON` line may still be getting lost or rejected before INFO logging
+
+I would now rank this below the UC-side theories, but it is still possible.
+
+The handoff is careful to say that absence of `PWON` in the logs means either:
+
+- the client never emitted `PWON`, or
+- the proxy never treated it as a logged command
+
+Even on the deployed `fix/clean-avr-commands` branch, a client line could still in principle fail to become an INFO `command:` log if:
+
+- it is malformed in a way the parser or validator drops
+- it decodes into something unexpected
+- it contains control bytes that cause `_is_valid_client_command()` rejection
+- it lands in a log path that never emits the expected INFO line
+
+What weakens this theory now:
+
+- the failure also occurs with `optimistic_state` disabled
+- `POST /api/refresh` does not help
+- the symptom pattern feels more like "UC stopped sending `PWON`" than "proxy keeps mangling one exact command forever"
+
+So I still consider it possible, but no longer likely enough to lead with.
+
+Confidence: **medium-low**
+
+---
+
+### 4. Why restart helps: restart is not just a refresh, it is a forced peer-side teardown
+
+The new handoff sharply improves this distinction.
+
+`POST /api/refresh` does this:
+
+- asks the proxy to query the AVR
+- obtains fresh `PW?`, `ZM?`, and other state
+- broadcasts answers to connected telnet clients
+
+Yet that does **not** resolve the UC issue.
+
+A full proxy restart additionally:
+
+- drops the UC socket from the server side
+- rebuilds the proxy process and its client handlers
+- rebuilds the proxy-to-AVR session
+- forces every client to reconnect to a new process
+
+That makes restart evidence point much more strongly toward:
+
+- a UC connection/session reset effect, or
+- some state in the proxy-client relationship that is only cleared by actual socket teardown
+
+and less strongly toward:
+
+- ordinary stale AVR state inside the proxy
+
+Confidence: **high**
+
+---
+
+## What changed from my prior analysis
+
+I am explicitly downgrading the earlier "false optimistic proxy power state" theory because the updated handoff says:
+
+- the same failure appears with `optimistic_state` off
+- `POST /api/refresh` still does not recover it
+
+If optimistic proxy state were the main root cause, I would expect at least one of those facts to cut strongly against the bug. Instead, both observations point upstream of optimistic broadcast behavior.
+
+I still think proxy state can be a contributing factor in some edge cases, but it is no longer my primary conclusion.
+
+---
+
+## Best-fit narrative
+
+The best fit to the updated handoff is now:
+
+1. UC works normally for a while and emits `PWON` / `PWSTANDBY`.
+2. At some point, the UC integration or pinned `denonavr` telnet/session state becomes stale or wedged.
+3. UC can still emit some commands, including `PWSTANDBY`, but later "power on" actions stop resulting in an outbound `PWON`.
+4. Because no `PWON` is actually emitted, the proxy logs no `Client ... command: PWON`.
+5. Home Assistant continues to work because it is a different client with a simpler power-control path.
+6. `POST /api/refresh` does not help because the bad state is not merely "proxy has stale AVR data."
+7. Restarting `denon-proxy` helps because it forces a true client-facing disconnect and a full session rebuild.
+
+That is the explanation I would currently bet on first.
+
+---
+
+## What would most quickly prove or disprove this
+
+1. On a failed UC power-on attempt, capture whether **any** bytes arrive at the proxy socket from the UC client.
+2. If bytes arrive, capture the exact line content before validation/log filtering.
+3. Correlate the first disappearance of UC `PWON` with any UC-side telnet reconnect, keepalive, or send-confirmation anomalies in UC logs.
+4. Compare two recovery actions side by side:
+   - `POST /api/refresh`
+   - full proxy restart
+   If only restart helps, that strongly favors a session-reset explanation over a pure state-refresh explanation.
+5. Test UC pointed directly at the AVR. If the same "no `PWON` emitted" behavior appears there, the proxy becomes much less likely as the primary cause.
+
+---
+
+## Confidence summary
+
+- **Top theory:** UC integration / pinned `denonavr` suppresses or fails to emit `PWON` after entering a stale state
+- **Strong secondary theory:** a wedged UC telnet/session state is only cleared by hard proxy-side disconnect and reconnect
+- **Lower-confidence proxy theory:** `PWON` is emitted but lost or rejected before proxy INFO logging
+- **What the new handoff most strongly rules out:** optimistic proxy state as the sole primary cause
+

--- a/docs/UC-POWER-BUG/agent-analyses/consensus-multi-agent-2026-04-05.md
+++ b/docs/UC-POWER-BUG/agent-analyses/consensus-multi-agent-2026-04-05.md
@@ -1,0 +1,73 @@
+# Consensus: UC Remote power-on failures via denon-proxy
+
+**Date:** 2026-04-05  
+**Purpose:** Synthesize the neutral handoff and three independent agent analyses in this folder. This is a meta-summary, not new primary research.
+
+**Sources:**
+
+- [UC Remote power handoff](../UC_REMOTE_POWER_ISSUE_HANDOFF.md) (`docs/UC-POWER-BUG/UC_REMOTE_POWER_ISSUE_HANDOFF.md`)
+- [claude-4.6-opus-2026-04-05.md](./claude-4.6-opus-2026-04-05.md)
+- [codex-agent-2026-04-05.md](./codex-agent-2026-04-05.md)
+- [cursor-claude-sonnet-4-5-2026-04-05.md](./cursor-claude-sonnet-4-5-2026-04-05.md)
+
+---
+
+## Summary of findings
+
+**Observed pattern (from handoff):** UC Remote 3 sometimes stops producing `PWON` in proxy logs while `PWSTANDBY` still appears; Home Assistant continues to control power through the same proxy; **only a full `denon-proxy` service restart** (not `POST /api/refresh`) temporarily restores behavior; the issue has been seen with **`optimistic_state` enabled and disabled**.
+
+**Mechanistic story (two of three agents — Opus and Sonnet):**
+
+1. For **single-zone** setups, power telnet events use **`PW`**, but **`PW`** is classified as an **all-zones** event (`zone == ALL_ZONES`) while **`_power_callback`** only updates when `zone == self.zone` (**`Main`**). The guard fails, so **`_power` is never updated from telnet**.
+2. The Unfolded Circle integration **`async_update_receiver_data`** can **skip HTTP `async_update()`** while telnet is “healthy,” assuming telnet callbacks keep `_power` current — which fails given (1).
+3. **`async_power_on()`** does `if self._power == "ON": return` with **no** telnet write → **no `PWON` in proxy logs**. **`async_power_off()`** is not symmetrically gated in the same way, so **`PWSTANDBY` can still be sent**.
+4. **`POST /api/refresh`** broadcasts real AVR answers but **does not** clear the bad `_power` for the single-zone path (details differ slightly between Opus vs Sonnet in how `PW` vs `ZM` refresh paths interact with callbacks, but both agree refresh is an insufficient recovery). **Restart** drops telnet → integration treats telnet as unhealthy → **HTTP runs again** → **`_power` realigns**.
+
+**Codex** agrees at the narrative level: UC / pinned **`denonavr`** gets into **stale internal power state**, **`async_power_on()`** suppresses **`PWON`**, and **hard reconnect** (proxy restart) resets that; it **does not** walk the **`ALL_ZONES` / `_power_callback`** line-by-line proof chain.
+
+---
+
+## Consensus
+
+| Point | Agreement |
+|--------|-----------|
+| Primary failure mode is **no `PWON` emitted** (suppression on the UC / `denonavr` path), not “proxy always drops power-on lines” | **Strong** — all three |
+| Involves **`denonavr` `_power` and `async_power_on()` early return** | **Strong** — all three (Codex narrative; Opus + Sonnet exact guards) |
+| **`optimistic_state` / proxy optimistic broadcasts** are **not** the root cause | **Strong** — handoff + all three |
+| **`POST /api/refresh` ≠ restart** implies the issue is **not** merely “stale AVR facts in the proxy”; aligns with **client/library state** or **paths only cleared by reconnect / HTTP** | **Strong** |
+| **HA** keeps working because it **does not** use the same **`_power`-gated `denonavr` power-on path** | **Strong** — Opus + Sonnet explicit; Codex consistent |
+| **`_power_callback` zone mismatch** (`Main` vs `All`) **plus** **HTTP skip while telnet healthy** as the **specific** mechanism | **Two of three** (Opus + Sonnet; Codex does not dispute, does not prove) |
+
+**Bottom line:** **Consensus** that the **dominant** issue lives in the **UC stack (`unfoldedcircle/integration-denonavr` + pinned `henrikwidlund/denonavr`)**, especially **silent suppression of `PWON`** via stale **`_power`**. **Full consensus on the exact zone-dispatch bug** is between **Opus and Sonnet**; **Codex** matches **symptoms and recovery** without that proof depth.
+
+---
+
+## Most common local cause (fixable in denon-proxy)
+
+Across analyses that name in-repo changes, the recurring **denon-proxy** mitigation is **`get_status_dump()` (and related snapshots) emitting `ZMON` / `ZMOFF` (ZM-family) alongside `PW*`** so multi-zone-style callbacks can see zone power on connect or broadcast. **Opus** and **Sonnet** both describe this as **defensive** and **insufficient by itself** to fix the **single-zone `_power_callback` zone mismatch**.
+
+**Opus** also recommends **verifying IAC stripping** on the deployed revision — secondary, not repeated in the other two.
+
+**Codex** still allows **proxy dropping or mangling `PWON` before INFO logging** as **possible** but **lower confidence** after the updated handoff.
+
+---
+
+## Most common upstream cause
+
+**Direction (unanimous):** **`unfoldedcircle/integration-denonavr`** + **pinned `henrikwidlund/denonavr`** (e.g. commit pinned in that integration’s `requirements.txt`): internal **`_power`** becomes **stale**, **`async_power_on()`** **short-circuits**, **`PWON` never reaches the wire**.
+
+**Specific pairing (Opus + Sonnet):** **`_power_callback` never updates `_power` for single-zone `PW` events** (zone guard + `PW` ∈ `ALL_ZONE_TELNET_EVENTS`) **and** **`async_update_receiver_data` skipping HTTP** while telnet looks healthy.
+
+**Preferred upstream fixes (per those writeups):** adjust **`_power_callback`** to treat **`ALL_ZONES`** (or equivalent), and/or **relax or remove** the **`_power == "ON"`** guard in **`async_power_on()`**; integration may need to **avoid relying solely on telnet** to refresh `_power` if that path is broken.
+
+---
+
+## `fix/clean-avr-commands` branch validity
+
+The analyses **do not** conclude that **`fix/clean-avr-commands`** is invalid or should be abandoned for this bug. Root cause is **upstream**; the issue appears with **`optimistic_state` on and off**. Proxy changes discussed are **additive** (e.g. **`ZM*` in status dump**, **IAC** verification), not “revert the branch.”
+
+**Consensus-consistent stance:** **keep the branch**; treat UC power-on as **primarily an integration / `denonavr` fix**, with **optional denon-proxy hardening**.
+
+---
+
+*This document is a synthesis only; re-verify pins, commits, and production branches before acting on upstream or deployment decisions.*

--- a/docs/UC-POWER-BUG/agent-analyses/cursor-agent-2026-04-04.md
+++ b/docs/UC-POWER-BUG/agent-analyses/cursor-agent-2026-04-04.md
@@ -1,0 +1,102 @@
+# Agent analysis: UC Remote power-on failures via denon-proxy
+
+**Agent:** Cursor (Claude)  
+**Date:** 2026-04-04  
+**Scope:** Conversation-derived conclusions about UC Remote 3 + denon-proxy + Home Assistant; compares with neutral handoff in `docs/UC_REMOTE_POWER_ISSUE_HANDOFF.md`.
+
+This file **does** prejudice cause: it records hypotheses, evidence, and recommended follow-ups from one analysis pass. Use it to compare with other agents’ writeups in this directory.
+
+---
+
+## Executive summary
+
+Observed symptoms are consistent with **more than one** contributing layer:
+
+1. **Proxy:** Client lines that are not valid UTF-8 (e.g. Telnet IAC bytes prepended to a command on the same line as `PWON`) were **silently dropped** in `parse_telnet_lines` before any `Client … command:` log or forward to the AVR. That matches “standby still logged, power-on vanishes from logs” when standby lines stay clean ASCII. A fix was implemented: strip IAC sequences before decode (`src/denon_proxy/avr/telnet_utils.py`).
+
+2. **Unfolded Circle stack (`integration-denonavr` + `denonavr`):** Internal `_power` used to gate `async_power_on` / `async_power_off` is updated from **`ZM`** telnet callbacks in `denonavr`’s `foundation.py`, while the integration’s UI/state path reacts strongly to **`PW`** events in `_telnet_callback`. The proxy’s optimistic `get_status_dump()` encodes power only as **`PW{state}`** (e.g. `PWON`, `PWSTANDBY`), not `ZMON`/`ZMOFF`. Non-idempotent early returns on send can then **skip** power commands while the remote UI reflects PW-driven state — consistent with “stuck either way” and with **HA** still working (HA’s legacy Denon component sends `PWON` without that library guard pattern).
+
+3. **Restart vs sleep/wake:** Client reconnect alone already resets the proxy↔client TCP handler and resends `get_status_dump()`. **Proxy process restart** additionally tears down **proxy↔AVR**, re-runs startup `request_state()`, and forces **all** clients through hard disconnect — often a stronger recovery path on the remote than a clean sleep/wake.
+
+None of these mutually exclude the others; production issues may be **additive**.
+
+---
+
+## Evidence inventory
+
+| Evidence | What it suggests |
+|----------|------------------|
+| Journal: UC `PWSTANDBY` continues; `PWON` absent over multi-day stretches; HA `PWON`/`PWSTANDBY` still present | Failure is **client-specific** or **path-specific**, not global AVR or proxy accept |
+| Same grep excludes `?` lines | Query traffic omitted; power **commands** should still appear if processed |
+| Double `PWON` within ~1s when working | Client retry or duplicate send when first attempt had no effect |
+| `systemctl restart denon-proxy` temporarily fixes | Reset of **AVR session** and/or **all clients’** error recovery, not only UC reconnect |
+| UC logs show frequent connect/disconnect (sleep/wake) | New proxy `ClientHandler` each time; **cannot** explain bug by “no fresh session” alone |
+| Code review: `parse_telnet_lines` used `decode('utf-8')` and `continue` on failure after consuming a line | **Whole line dropped** including trailing command if IAC prefix makes UTF-8 invalid |
+| Code review: `denonavr` `async_power_on` returns immediately if `_power == "ON"` | No Telnet write; **no proxy log line** if guard misfires |
+| Code review: `_power_callback` registers on **`ZM`**, not **`PW`**, in `foundation.py` | PW-heavy feed from proxy can desync `_power` vs integration `_expected_state` |
+
+---
+
+## Technical conclusions (ranked confidence)
+
+### High confidence
+
+- **Dropped client lines (UTF-8):** Reproduced locally: `b"\xff\xfePWON\r\n"` produced **no** parsed command before IAC stripping; after strip, `PWON` parses. Explains missing INFO logs and no forward when negotiation bytes prefix a command.
+
+- **Proxy optimistic broadcast shape:** `AVRState.get_status_dump()` always emits **`PW…`** for power, never **`ZM…`**, even when the inbound command was `ZMON`/`ZMOFF`. Factual from `state.py`.
+
+### Medium confidence
+
+- **`denonavr` split state (PW vs ZM):** The integration updates display/state from **`PW`** in `avr.py` `_telnet_callback`; `denonavr`’s `_power` gate for sends follows **`ZM`**-driven `_power_callback`. Factual separation; **impact** depends on live traffic mix (real AVR still emits `ZM` responses when queried or toggled).
+
+- **Coarse send confirmation in `denonavr`:** `_send_confirmation_callback` matches on **event prefix** (`_get_event`), not full command string — any `ZM…` line can confirm a pending `ZMON` waiter. May cause ordering edge cases under multi-writer broadcast; secondary to the main symptom set.
+
+### Lower confidence / needs capture
+
+- Exact bytes on wire when UC “on” fails **post** IAC fix.
+- Whether deployed UC build sends `PWON`/`PWSTANDBY` vs `ZMON`/`ZMOFF` (local `denonavr` const uses `ZMON`/`ZMOFF`; user journals showed `PW*`).
+
+---
+
+## Code touchpoints (repository paths)
+
+**denon-proxy (this repo)**
+
+- `src/denon_proxy/avr/telnet_utils.py` — line parsing, IAC strip, UTF-8 decode
+- `src/denon_proxy/proxy/core.py` — `ClientHandler`, logging, optimistic broadcast, `connection_made` welcome dump
+- `src/denon_proxy/avr/state.py` — `get_status_dump()`, `apply_command`, `update_from_message`
+
+**integration-denonavr** (sibling / external clone)
+
+- `intg-denonavr/avr.py` — `_telnet_callback` (`PW` → `_set_expected_state`)
+- Pinned library: `henrikwidlund/denonavr` per `requirements.txt`
+
+**denonavr**
+
+- `denonavr/foundation.py` — `async_power_on`, `async_power_off`, `_register_callbacks` / `_power_callback` (`ZM`)
+- `denonavr/api.py` — `DenonAVRTelnetProtocol`, `_process_event`, `_send_confirmation_callback`, `request_state`-style query bursts / keepalive
+
+**Home Assistant (comparison)**
+
+- `homeassistant/components/denon/media_player.py` — `turn_on` / `turn_off` → `PWON` / `PWSTANDBY` without the same `denonavr` `_power` short-circuit
+
+---
+
+## Changes made during this analysis (denon-proxy)
+
+- **`_strip_telnet_sequences`** + use before UTF-8 decode in `parse_telnet_lines`; tests in `tests/unit/test_telnet_utils.py`.
+
+---
+
+## Recommended verification
+
+1. On failure: tcpdump or proxy debug of **raw** client ingress bytes for a failed power-on tap.
+2. UC integration debug logs around `async_power_on` / telnet send when UI shows off but no line hits proxy.
+3. After IAC fix: re-check journals for sustained “no `PWON` from UC” windows.
+4. If still failing: patch **`denonavr`** or integration (PW also drives `_power`, or remove/skip send guards for telnet, or emit `ZM…` in proxy status dump) — **outside** this repo unless vendored.
+
+---
+
+## Comparison note
+
+Place sibling agent outputs in `docs/agent-analyses/` with a stable naming scheme (e.g. `<tool>-<date>.md`) so diffs in conclusions and evidence are easy to scan.

--- a/docs/UC-POWER-BUG/agent-analyses/cursor-claude-sonnet-4-5-2026-04-05.md
+++ b/docs/UC-POWER-BUG/agent-analyses/cursor-claude-sonnet-4-5-2026-04-05.md
@@ -1,0 +1,246 @@
+# Agent analysis: UC Remote power-on failures via denon-proxy
+
+**Agent:** Cursor (claude-4.6-sonnet-thinking)
+**Date:** 2026-04-05 (updated same day from revised handoff)
+**Sources used:** GitHub at the exact revisions named in the handoff — no local trees.
+
+| Source | Commit / version |
+|--------|-----------------|
+| `unfoldedcircle/integration-denonavr` | `main` |
+| `henrikwidlund/denonavr` | `7c77360db681f3c3f8c27bcf53f318adabee37a0` (pinned in integration's `requirements.txt`) |
+| `denon-proxy` | current branch (`fix/clean-avr-commands`) |
+
+---
+
+## New evidence incorporated from updated handoff
+
+The handoff was revised with two additions that sharpen the analysis:
+
+**Symptom 1 clarified:** "the proxy logs show no corresponding `Client … command: PWON` (INFO-level line) from the UC Remote for those power-on attempts—the command simply never appears in journald as originating from that client." The absence is specifically at the INFO logging level, confirming the command is never processed through `ClientHandler._handle_command` at info severity.
+
+**New symptom 5:** "Web UI 'Refresh from AVR' (`POST /api/refresh`, which triggers `request_state()` / `PW?`, `MV?`, `ZM?`, … query sequence to the physical AVR and broadcasts answers to connected Telnet clients) **does not** resolve the UC Remote power/sync problem when this failure mode is active — unlike restarting the `denon-proxy` service."
+
+This is the single most diagnostic data point in the handoff. It eliminates the proxy's state tracking as a cause and provides a definitive test to distinguish single-zone from multi-zone as the active failure path. See "Why 'Refresh from AVR' fails to fix it" below.
+
+**Configuration note added:** The same failure has been observed with `optimistic_state` both enabled and disabled. This rules out the optimistic broadcast path as the root cause.
+
+---
+
+## Executive summary
+
+The failure is caused by **two interacting design decisions in the pinned `denonavr` library** that together make `_power` permanently stale in the denonavr object once telnet is established:
+
+1. **`_power_callback` is a dead code path for single-zone receivers.** `PW` events arrive with `zone = ALL_ZONES`, but the callback guards on `self.zone == zone` (MAIN_ZONE ≠ ALL_ZONES). The guard never passes, so `_power` is never updated from any telnet event.
+
+2. **`async_update_receiver_data` skips HTTP updates while telnet is healthy.** Once telnet is stable, the HTTP `async_update()` call that would refresh `_power` is bypassed. The system relies entirely on `_power_callback` to keep `_power` current — which, per (1), never fires.
+
+The combination means `_power` freezes at the value it had when the telnet connection first became healthy. When the receiver transitions to standby (e.g. via HA's `PWSTANDBY`), `_power` stays "ON". The next call to `async_power_on()` sees `_power == "ON"`, silently returns without writing to the socket, and nothing reaches the proxy or the AVR.
+
+---
+
+## Evidence that the receiver is single-zone
+
+The representative log contains:
+
+```
+Client UC Remote 3 (10.0.3.10) command: PWSTANDBY
+```
+
+`PWSTANDBY` (not `ZMOFF`) is UC Remote's power-off command. From `denonavr/const.py` (pinned commit):
+
+```python
+DENONAVR_TELNET_COMMANDS = TelnetCommands(
+    ...
+    command_power_on="ZMON",
+    command_power_standby="ZMOFF",
+    ...
+)
+```
+
+And from `denonavr/foundation.py` `_register_callbacks()`:
+
+```python
+def _register_callbacks(self):
+    power_event = "ZM"
+    ...
+    elif self.zones == 1:
+        # ZM events do not always work when the receiver has only one zone
+        power_event = "PW"
+        self.telnet_commands = self.telnet_commands._replace(
+            command_power_on="PWON", command_power_standby="PWSTANDBY"
+        )
+    self.telnet_api.register_callback(power_event, self._power_callback)
+```
+
+`PWSTANDBY` appears in the proxy log because `self.zones == 1` — the operator's receiver reports itself to denonavr as single-zone. In that branch, the library switches both the **send commands** and the **callback registration** from `ZM` to `PW`.
+
+---
+
+## Bug 1: `_power_callback` is a dead code path for single-zone receivers
+
+`_power_callback` in `foundation.py`:
+
+```python
+def _power_callback(self, zone: str, _event: str, parameter: str) -> None:
+    """Handle a power change event."""
+    if self.zone == zone and parameter in POWER_STATES:
+        self._power = parameter
+```
+
+`_power` is the field that gates `async_power_on()` and `async_power_off()`:
+
+```python
+async def async_power_on(self) -> None:
+    """Turn on receiver."""
+    if self._power == "ON":
+        return  # ← silent early return; no telnet write, no proxy log
+    if self.telnet_available:
+        await self.telnet_api.async_send_commands(
+            self.telnet_commands.command_power_on
+        )
+    ...
+```
+
+Now trace how `PW` events are dispatched. In `api.py` `_process_event()`:
+
+```python
+zone = MAIN_ZONE
+if event in ALL_ZONE_TELNET_EVENTS:
+    zone = ALL_ZONES
+...
+self._run_callbacks(message, event, zone, parameter)
+```
+
+And `PW` is in `ALL_ZONE_TELNET_EVENTS` (`const.py`):
+
+```python
+ALL_ZONE_TELNET_EVENTS = {
+    ...
+    "PW",
+    ...
+}
+```
+
+So every `PW` message — including `PWON` and `PWSTANDBY` — arrives at `_power_callback` with `zone = ALL_ZONES = "All"`.
+
+But `self.zone = MAIN_ZONE = "Main"` for the main zone. The guard `self.zone == zone` becomes `"Main" == "All"` → **False**. The callback body never executes. **`_power` is never updated by any telnet event for single-zone receivers.**
+
+This is not a hypothetical: it is structurally guaranteed by `PW` being in `ALL_ZONE_TELNET_EVENTS`.
+
+---
+
+## Bug 2: HTTP `async_update()` is skipped while telnet is healthy
+
+`async_update_receiver_data()` in the UC integration's `avr.py`:
+
+```python
+# We can only skip the update if telnet was healthy after
+# the last update and is still healthy now to ensure that
+# we don't miss any state changes while telnet is down
+# or reconnecting.
+if (telnet_is_healthy := self._telnet_healthy) and self._telnet_was_healthy:
+    if force:
+        await receiver.async_update()
+        ...
+    self._notify_updated_data()
+    return  # ← skips async_update() entirely
+```
+
+Once the telnet connection has been healthy across two consecutive update cycles, all calls to `async_update_receiver_data()` bypass `receiver.async_update()` (the HTTP fetch that updates `_power`). The code comment makes clear this is intentional — it is intended to reduce HTTP chatter when telnet is handling state. But since `_power_callback` never fires for PW events (Bug 1), there is no telnet path that can substitute for the skipped HTTP update.
+
+---
+
+## Combined failure scenario (step by step)
+
+1. UC Remote wakes; proxy sees a new TCP connection; sends `get_status_dump()` → `PWON` (receiver is on).
+2. denonavr's UC integration calls `async_telnet_connect()` and `async_update()` (HTTP).
+3. HTTP fetch to proxy's `MainZoneXml` endpoint → `_power = "ON"` (correct; receiver is on).
+4. Telnet connection stabilizes; `_telnet_healthy = True`, `_telnet_was_healthy = True` on the next update cycle.
+5. **From this point, all `async_update_receiver_data()` calls skip `async_update()`.**
+6. HA issues `PWSTANDBY` via the proxy; AVR enters standby; proxy state becomes `"STANDBY"`.
+7. Proxy broadcasts `PWSTANDBY` to UC's telnet connection.
+8. UC integration's `_telnet_callback` fires (it accepts `zone = ALL_ZONES`): `_set_expected_state(States.OFF)` — the UC remote UI shows the device as off. ✓
+9. **`_power_callback` fires with `zone = ALL_ZONES`, but `self.zone == zone` fails — `_power` stays "ON".**
+10. User presses **power on** on the UC Remote.
+11. Integration calls `power_on()` → `self._receiver.async_power_on()`.
+12. `async_power_on()`: `self._power == "ON"` → **returns immediately. No socket write. No proxy log line.**
+13. Integration calls `_schedule_update_task()`.
+14. `async_update_receiver_data()`: telnet is healthy → **skips HTTP** → `_power` unchanged → stays "ON".
+15. The state is now self-reinforcing: every power-on attempt no-ops; nothing clears `_power`.
+
+### Why proxy restart breaks the cycle
+
+Proxy restart drops every telnet connection. UC Remote's telnet to the proxy closes. On the next reconnect:
+- `_telnet_healthy = False` (connection was lost).
+- UC reconnects; `async_update_receiver_data()` now calls `async_update()` (HTTP) because telnet was not healthy.
+- HTTP fetches proxy's `MainZoneXml` → `_power = "STANDBY"` (correct; proxy state is "STANDBY").
+- Next `async_power_on()`: `_power == "STANDBY"` → sends `PWON` → proxy logs it → AVR wakes. ✓
+
+The proxy service restart is effectively forcing the telnet health state to reset, triggering the only code path that can refresh `_power`.
+
+### Why HA is unaffected
+
+The Home Assistant `denon` component (`homeassistant/components/denon/media_player.py`) does not use the denonavr library for power control. Its `turn_on()` writes `PWON` directly via telnet without any `_power` guard. There is no early-return mechanism to break.
+
+### Why "Refresh from AVR" does not fix it — and why this confirms single-zone
+
+`POST /api/refresh` triggers `AVRConnection.request_state()`, which among other queries sends `ZM?` to the physical AVR. The AVR responds with `ZMON` or `ZMOFF`. The proxy relays that line verbatim to all connected telnet clients, including UC Remote.
+
+**For a multi-zone receiver** (where `_power_callback` is registered on `"ZM"`): when UC Remote receives `ZMOFF`, the denonavr event dispatch routes it to `_power_callback` with `zone = MAIN_ZONE`. The guard `self.zone == zone` → `"Main" == "Main"` → **True**. `_power` updates to `"OFF"`. The bug clears on the next power-on attempt. In other words, "Refresh from AVR" *would* fix multi-zone receivers.
+
+**For a single-zone receiver** (where `_power_callback` is registered on `"PW"`, not `"ZM"`): no callback is registered on the `"ZM"` event. When UC Remote receives `ZMOFF`, the event is dispatched but finds no `ZM` listener that updates `_power`. `_power` stays `"ON"`. The bug is unaffected.
+
+The operator reports that "Refresh from AVR" does **not** fix the problem. This is only consistent with the single-zone code path. It is therefore not merely supporting evidence for Bug 1 — it is a direct empirical confirmation of the mechanism.
+
+**Why full restart does fix it:** A service restart closes the proxy–UC telnet connection. On reconnect, `_telnet_healthy` is `False`, so `async_update_receiver_data()` is forced to call `async_update()` (HTTP). The proxy's `MainZoneXml` endpoint correctly returns `power = "STANDBY"`. denonavr parses `./ZonePower/value` → `_power = "STANDBY"`. The HTTP path does not depend on `_power_callback` or any zone-event routing, so it succeeds regardless of the single/multi-zone branch. `async_power_on()` can now send `PWON`.
+
+---
+
+## Secondary observation: `get_status_dump()` emits only `PW*`, never `ZM*`
+
+For multi-zone receivers (where `_power_callback` is registered on `ZM`, correctly), `_power` is updated when the AVR emits `ZMON` or `ZMOFF`. The proxy relays real AVR responses verbatim, so `ZMOFF` from the AVR reaches UC. **But when the receiver goes to standby via HA's `PWSTANDBY` command, the AVR may respond with `PWSTANDBY` only, not `ZMOFF`.** In that case, `_power_callback` never fires (no `ZM` event), and the skip-HTTP optimization (Bug 2) again prevents recovery. This explains why multi-zone users could see the same symptom.
+
+The proxy's `AVRState.get_status_dump()` always emits `PW{state}`, not `ZMON`/`ZMOFF`. Status dumps sent on reconnect (`connection_made`) and on optimistic broadcast (`_broadcast_state`) therefore never trigger `_power_callback` for multi-zone receivers either. Adding `ZMON`/`ZMOFF` to `get_status_dump()` would partially mitigate this for multi-zone receivers, but would not fix the broken zone-check guard (Bug 1) for single-zone receivers.
+
+---
+
+## Summary table
+
+| # | Where | What | Effect |
+|---|-------|------|--------|
+| 1 | `denonavr/api.py` `_process_event` | `PW` in `ALL_ZONE_TELNET_EVENTS` → zone set to `ALL_ZONES` | `_power_callback` zone guard always fails for single-zone receivers |
+| 2 | `denonavr/foundation.py` `_power_callback` | `self.zone == zone` check | Dead code for single-zone receivers; `_power` frozen |
+| 3 | `intg-denonavr/avr.py` `async_update_receiver_data` | Skip HTTP when telnet healthy | No path to refresh stale `_power`; self-reinforcing deadlock |
+| 4 | `denonavr/foundation.py` `async_power_on` | `if self._power == "ON": return` | Silent no-op when `_power` is stale; nothing logged at proxy |
+
+**Empirical discriminators (from updated handoff):**
+
+| Observation | Consistent with single-zone Bug 1+2? | Consistent with multi-zone? |
+|-------------|--------------------------------------|------------------------------|
+| "Refresh from AVR" (`ZM?` → `ZMOFF` broadcast) does not fix the bug | ✓ — no ZM callback registered; `_power` unaffected | ✗ — ZMOFF would trigger ZM-registered `_power_callback` and fix it |
+| Full proxy restart fixes the bug | ✓ — forces HTTP update path | ✓ |
+| `PWSTANDBY` (not `ZMOFF`) in proxy log from UC Remote | ✓ — confirms `zones == 1` branch | ✗ |
+| `optimistic_state` on/off makes no difference | ✓ — bug is in denonavr, not proxy broadcast | ✓ |
+
+---
+
+## Recommended verification
+
+1. **Confirm single-zone**: Check whether denonavr logs `zones == 1` during setup, or capture the `GetAllZonePowerStatus` AppCommand response the integration receives from the proxy on startup.
+
+2. **Instrument `_power`**: Add a debug log of `self._power` at the top of `async_power_on()` in the pinned denonavr fork. If it shows "ON" when the AVR is in standby, Bug 1 + 2 are confirmed.
+
+3. **Reproduce without proxy**: Point UC Remote directly at the AVR. If the bug also appears there (HA turns off via PWSTANDBY, UC can't turn on), the bug is entirely in the denonavr library and is proxy-independent.
+
+4. **Proposed fix — in denonavr**: In `_power_callback`, also accept `zone == ALL_ZONES` for the `PW` registration case, e.g.:
+   ```python
+   if (self.zone == zone or zone == ALL_ZONES) and parameter in POWER_STATES:
+       self._power = parameter
+   ```
+   This would let `PWSTANDBY` and `PWON` correctly update `_power` for single-zone receivers.
+
+5. **Proxy-side mitigation**: Include `ZMON`/`ZMOFF` in `get_status_dump()` alongside `PWON`/`PWSTANDBY`. This won't fix the zone-check bug but gives multi-zone receivers a ZM-family event on every reconnect, so `_power_callback` fires correctly from the welcome dump.
+
+---
+
+*Sources read: `henrikwidlund/denonavr` `foundation.py`, `api.py`, `const.py` at commit `7c77360`; `unfoldedcircle/integration-denonavr` `avr.py` at `main`; `denon-proxy` `src/denon_proxy/avr/state.py`, `src/denon_proxy/avr/discovery.py`, `src/denon_proxy/proxy/core.py`.*

--- a/src/denon_proxy/avr/state.py
+++ b/src/denon_proxy/avr/state.py
@@ -34,6 +34,11 @@ def _normalize_smart_select(value: str | None) -> str | None:
     return None
 
 
+def _zm_line_for_power(power: str) -> str:
+    """Telnet zone-main power line matching PW state (for status dumps and multi-zone clients)."""
+    return "ZMON" if power.upper() == "ON" else "ZMOFF"
+
+
 def _parse_mvmax(param: str) -> float | None:
     """Parse MVMAX nn from param (e.g. 'MAX 60' or 'MAX60'). Returns None if no number."""
     if not param.upper().startswith("MAX"):
@@ -128,6 +133,7 @@ class AVRState:
         lines = []
         if self.power:
             lines.append(f"PW{self.power}")
+            lines.append(_zm_line_for_power(self.power))
         if self.volume:
             lines.append(f"MV{self.volume}")
         if self.input_source:

--- a/tests/unit/test_avr_connection_virtual.py
+++ b/tests/unit/test_avr_connection_virtual.py
@@ -47,8 +47,9 @@ async def test_virtual_avr_request_state_pushes_status_dump_lines():
     assert recorded == expected, (
         f"on_response should be called with lines from get_status_dump(); got {recorded!r}, expected {expected!r}"
     )
-    # Sanity: we expect PW, MV, SI, MU, MS, and optionally MSSMART
+    # Sanity: we expect PW, ZM, MV, SI, MU, MS, and optionally MSSMART
     assert any(line.startswith("PW") for line in recorded)
+    assert any(line.startswith("ZM") for line in recorded)
     assert any(line.startswith("MV") for line in recorded)
     assert any(line.startswith("SI") for line in recorded)
     assert any(line.startswith("MU") for line in recorded)
@@ -78,7 +79,7 @@ async def test_virtual_avr_request_state_standby_pushes_full_dump():
 
     expected = [line.strip() for line in state.get_status_dump().strip().splitlines() if line.strip()]
     assert recorded == expected
-    assert recorded == ["PWSTANDBY", "MV45", "SIHDMI1", "MUOFF", "MSSTEREO"]
+    assert recorded == ["PWSTANDBY", "ZMOFF", "MV45", "SIHDMI1", "MUOFF", "MSSTEREO"]
 
 
 @pytest.mark.asyncio
@@ -130,8 +131,8 @@ async def test_virtual_avr_send_command_empty_or_short_returns_true():
 
 
 @pytest.mark.asyncio
-async def test_virtual_avr_send_command_pwon_emits_pwon_only():
-    """send_command('PWON') emits PWON only (status dump has no synthetic ZM)."""
+async def test_virtual_avr_send_command_pwon_emits_pw_and_zm_status_lines():
+    """send_command('PWON') emits PW and ZM lines from get_status_dump (power group)."""
     state = AVRState()
     state.power = "STANDBY"
     recorded = []
@@ -149,7 +150,7 @@ async def test_virtual_avr_send_command_pwon_emits_pwon_only():
     )
     await avr.connect()
     await avr.send_command("PWON")
-    assert recorded == ["PWON"]
+    assert recorded == ["PWON", "ZMON"]
     assert state.power == "ON"
 
 

--- a/tests/unit/test_avr_state_core.py
+++ b/tests/unit/test_avr_state_core.py
@@ -118,6 +118,7 @@ def test_apply_command_and_get_status_dump_and_snapshot_restore():
     dump = state.get_status_dump()
     # Status dump should include core lines reflecting updated state
     assert "PWON" in dump
+    assert "ZMON" in dump
     assert "MV" in dump
     assert "MUON" in dump
     assert "SIHDRADIO" in dump
@@ -138,7 +139,7 @@ def test_get_status_dump_power_standby_includes_tracked_zone_state():
     state.power = "STANDBY"
     dump = state.get_status_dump()
     lines = [ln.strip() for ln in dump.strip().splitlines() if ln.strip()]
-    assert lines == ["PWSTANDBY", "MV50", "SICD", "MUOFF", "MSSTEREO"]
+    assert lines == ["PWSTANDBY", "ZMOFF", "MV50", "SICD", "MUOFF", "MSSTEREO"]
 
 
 def test_get_status_dump_standby_includes_volume_input_sound():
@@ -150,7 +151,7 @@ def test_get_status_dump_standby_includes_volume_input_sound():
     state.sound_mode = "STEREO"
     dump = state.get_status_dump()
     lines = [ln.strip() for ln in dump.strip().splitlines() if ln.strip()]
-    assert lines == ["PWSTANDBY", "MV45", "SIHDMI1", "MUOFF", "MSSTEREO"]
+    assert lines == ["PWSTANDBY", "ZMOFF", "MV45", "SIHDMI1", "MUOFF", "MSSTEREO"]
 
 
 def test_apply_payload_normalizes_smart_select():


### PR DESCRIPTION
The potential fix in this branch:
- send ZM(ON|OFF) when turning the receiver on and off
- denon-proxy is currently running this branch

see docs/UC-POWER-BUG/UC_REMOTE_POWER_ISSUE_HANDOFF.md for info

At the same time, the UC sim is running with proxy added:
- http://10.0.1.16:8082/configurator#/entity/denonavr-dev.main.media_player.0006782A0B98
- sim is running the denon integration [updated](https://github.com/forsethc/integration-denonavr/commit/c4f5aa19c2ef397a32488d7d35b193766da14687) to [use my own fork of denonavr](https://github.com/forsethc/denonavr/commit/4b5694ee4fdcdcca80b6aba3527b3fcbdfc404f9)
  - if this PR doesn't fix it, we may need to contribute upstream
  - PR that potentially caused the issue in the first place
    - https://github.com/henrikwidlund/denonavr/pull/10